### PR TITLE
docs(market): sync command and config docs with market expansion

### DIFF
--- a/docs/en/md/command.md
+++ b/docs/en/md/command.md
@@ -369,6 +369,9 @@ And the plugins provide the following commands for simple interaction:
 [Server] Usage:
 [Server] - /market gui
 [Server] - /market reload
+[Server] - /market report [Days: int]
+[Server] - /market tax
+[Server] - /market tax <Rate: string>
 ```
 
 > [!TIP]
@@ -379,6 +382,17 @@ And the plugins provide the following commands for simple interaction:
 
 - `/market reload`
   - Reload (recompile) the player market GUI (permission level: GameDirectors).
+
+- `/market report [Days]`
+  - View the market report (trade count, turnover, tax, active sellers), default statistics window is 7 days (permission level: GameDirectors).
+  - Here, `[Days: int]` is the statistics window in days.
+
+- `/market tax`
+  - Show the current market transaction tax rate (permission level: GameDirectors).
+
+- `/market tax <Rate>`
+  - Set the market transaction tax rate at runtime, effective immediately and persisted (permission level: GameDirectors).
+  - Here, `<Rate: string>` is the tax rate as a decimal (range 0.0 ~ 1.0).
 
 > [!TIP]
 > Can you see me? ( •̀ ω •́ )✧

--- a/docs/en/md/data.md
+++ b/docs/en/md/data.md
@@ -130,7 +130,22 @@ When you upgrade the plugin version, newly added configuration items are automat
                 "StoreTransactionWindowDays": 30, // Store transaction data statistics window (in days)
                 "StoreRatingWindowDays": 180, // Store review data statistics window (in days)
                 "StoreRiskWindowDays": 30, // Store risk data statistics window (in days)
-                "StoreRankRefreshMinutes": 60 // Store leaderboard refresh interval (in minutes)
+                "StoreRankRefreshMinutes": 60, // Store leaderboard refresh interval (in minutes)
+                "StoreQuoteEnabled": true, // Whether to enable quote aggregation (average price, volume and turnover rankings)
+                "StoreQuoteRefreshMinutes": 30, // Quote refresh interval (in minutes)
+                "StoreTransactionTaxRate": 0.0, // Transaction tax rate (0.0 ~ 1.0, floor(price × rate); can be overridden at runtime via /market tax)
+                "StorePriceCeilingRatio": 0.0, // Price ceiling ratio (based on the 30-day average price; listings above average × ratio are rejected, 0 disables)
+                "StoreWantedEnabled": true, // Whether to enable wanted orders
+                "StoreWantedMaxPerPlayer": 5, // Maximum number of concurrent wanted orders per player
+                "StoreWantedExpireDays": 7, // Wanted order expiry (in days; frozen prepayment is refunded on expiry)
+                "StorePartialBuyEnabled": true, // Whether to enable partial fulfillment of wanted orders
+                "StoreAuctionEnabled": true, // Whether to enable auctions
+                "StoreAuctionMinDurationMinutes": 30, // Minimum auction duration (in minutes)
+                "StoreAuctionMaxDurationHours": 72, // Maximum auction duration (in hours)
+                "StoreAuctionMinBidIncrement": 1.05, // Minimum bid increment ratio (a new bid must exceed current price × ratio)
+                "StoreAuctionAntiSnipeSeconds": 0, // Anti-sniping duration (in seconds; late bids extend the auction, 0 disables)
+                "StoreRepeatTradeLimit": 3, // Repeat trade count limit per trade pair (excess trades are excluded from average price, anti-farming)
+                "StorePriceOutlierRatio": 0.0 // Outlier price filter ratio (trades deviating beyond this multiple of the recent average are excluded, 0 disables)
             },
             "BehaviorEvent": { // Behavior event configuration
                 "ModuleEnabled": false, // Whether to enable behavior events

--- a/docs/md/command.md
+++ b/docs/md/command.md
@@ -369,6 +369,9 @@
 [Server] Usage:
 [Server] - /market gui
 [Server] - /market reload
+[Server] - /market report [Days: int]
+[Server] - /market tax
+[Server] - /market tax <Rate: string>
 ```
 
 > [!TIP]
@@ -379,6 +382,17 @@
 
 - `/market reload`
   - 重新加载（重新编译）玩家市场 GUI（权限等级: GameDirectors）。
+
+- `/market report [Days]`
+  - 查看市场经营报表（成交笔数、成交总额、税收总额、活跃卖家数），统计窗口默认 7 天（权限等级: GameDirectors）。
+  - 其中 `[Days: int]` 为统计窗口天数。
+
+- `/market tax`
+  - 查询当前市场交易税率（权限等级: GameDirectors）。
+
+- `/market tax <Rate>`
+  - 运行时设置市场交易税率，立即生效并持久化（权限等级: GameDirectors）。
+  - 其中 `<Rate: string>` 为税率小数（范围 0.0 ~ 1.0）。
 
 > [!TIP]
 > 你看到我了吗？( •̀ ω •́ )✧

--- a/docs/md/data.md
+++ b/docs/md/data.md
@@ -130,7 +130,22 @@
                 "StoreTransactionWindowDays": 30, // 商店交易数据统计窗口（单位为天）
                 "StoreRatingWindowDays": 180, // 商店评价数据统计窗口（单位为天）
                 "StoreRiskWindowDays": 30, // 商店风险数据统计窗口（单位为天）
-                "StoreRankRefreshMinutes": 60 // 商店排行榜刷新间隔（单位为分钟）
+                "StoreRankRefreshMinutes": 60, // 商店排行榜刷新间隔（单位为分钟）
+                "StoreQuoteEnabled": true, // 是否启用行情聚合（成交均价、成交量与成交额排行）
+                "StoreQuoteRefreshMinutes": 30, // 行情刷新间隔（单位为分钟）
+                "StoreTransactionTaxRate": 0.0, // 交易税税率（0.0 ~ 1.0，成交价 × 税率向下取整；可被 /market tax 运行时覆盖）
+                "StorePriceCeilingRatio": 0.0, // 价格上限比例（基于近 30 天均价，超过均价 × 比例的定价将被拦截，为 0 时关闭）
+                "StoreWantedEnabled": true, // 是否启用求购单功能
+                "StoreWantedMaxPerPlayer": 5, // 单个玩家最大同时挂单数量
+                "StoreWantedExpireDays": 7, // 求购单过期天数（过期后自动退还冻结预付款）
+                "StorePartialBuyEnabled": true, // 是否启用求购单部分成交
+                "StoreAuctionEnabled": true, // 是否启用拍卖功能
+                "StoreAuctionMinDurationMinutes": 30, // 拍卖最短时长（单位为分钟）
+                "StoreAuctionMaxDurationHours": 72, // 拍卖最长时长（单位为小时）
+                "StoreAuctionMinBidIncrement": 1.05, // 最低加价比例（新出价须高于当前价 × 该比例）
+                "StoreAuctionAntiSnipeSeconds": 0, // 防狙击时长（单位为秒，尾盘出价自动延长；为 0 时关闭）
+                "StoreRepeatTradeLimit": 3, // 同一交易对重复成交计数上限（超过后不计入行情均价，防刷量）
+                "StorePriceOutlierRatio": 0.0 // 离群价过滤比例（偏离近期均价超过该倍数的成交不计入均价，为 0 时关闭）
             },
             "BehaviorEvent": { // 行为事件配置
                 "ModuleEnabled": false, // 是否启用行为事件


### PR DESCRIPTION
补充 PR #21 合并时未包含的文档同步（该提交在合并后推送到分支）。

## 命令文档（中/英）
- 补全 `/market report [Days]`：经营报表（笔数/成交额/税收/活跃卖家）
- 补全 `/market tax` 与 `/market tax <Rate>`：税率查询与运行时设置
- Usage 代码块同步为实际注册的 5 个 overload

## 配置文档（中/英）
- Market 配置示例从 23 项补全到 38 项，新增 15 个选项说明：
  - 行情聚合：`StoreQuoteEnabled` / `StoreQuoteRefreshMinutes`
  - 经济治理：`StoreTransactionTaxRate` / `StorePriceCeilingRatio`
  - 求购单：`StoreWantedEnabled` / `StoreWantedMaxPerPlayer` / `StoreWantedExpireDays` / `StorePartialBuyEnabled`
  - 拍卖：`StoreAuctionEnabled` / 时长限制 / `StoreAuctionMinBidIncrement` / `StoreAuctionAntiSnipeSeconds`
  - 反作弊：`StoreRepeatTradeLimit` / `StorePriceOutlierRatio`

纯文档改动，不触发 CI 构建。