### PR TITLE
feat(frontend): address locals by slot and split debug info into a si…

### DIFF
--- a/src/LOICollectionA/frontend/AST.h
+++ b/src/LOICollectionA/frontend/AST.h
@@ -850,12 +850,11 @@ namespace LOICollection::frontend {
 
         int bodyIndex = -1;
         int argCount = 0;
-        std::vector<std::string> paramNames;
 
         bool hasThis = false;
         ObjectRef thisObj;
-        
-        std::unordered_map<std::string, ValueNode::ValueType> captures;
+
+        std::vector<ValueNode::ValueType> captures;
         std::unordered_map<std::string, ValueNode::ValueType> globals;
     };
 }

--- a/src/LOICollectionA/frontend/ir/ByteCode.h
+++ b/src/LOICollectionA/frontend/ir/ByteCode.h
@@ -61,7 +61,6 @@ namespace LOICollection::frontend::ir {
 
     struct MethodMeta {
         std::string name;
-        std::vector<std::string> paramNames;
         int argCount = 0;
         int classIndex = -1;
         int bodyIndex = -1;
@@ -70,7 +69,7 @@ namespace LOICollection::frontend::ir {
     struct LambdaMeta {
         int bodyIndex = -1;
         int argCount = 0;
-        std::vector<std::string> paramNames;
+        int captureCount = 0;
     };
 
     struct NativeCallMeta {
@@ -97,6 +96,8 @@ namespace LOICollection::frontend::ir {
          * MSVC STL's std::deque does not support an incomplete value type
          * (a self-referencing member), while libstdc++ accepts it. */
         std::deque<std::unique_ptr<BytecodeChunk>> methodBodies;
+
+        int slotCount = 0;
 
         size_t emit(OpCode op, int operand = 0, const SourceLocation& loc = {}) {
             this->code.push_back({op, operand, loc});

--- a/src/LOICollectionA/frontend/ir/BytecodeSerializer.cpp
+++ b/src/LOICollectionA/frontend/ir/BytecodeSerializer.cpp
@@ -213,9 +213,6 @@ namespace LOICollection::frontend::ir {
         void writeInstruction(Writer& writer, const Instruction& instr) {
             writer.u8(static_cast<uint8_t>(instr.op));
             writer.i32(instr.operand);
-            writer.u64(instr.loc.line);
-            writer.u64(instr.loc.column);
-            writer.u64(instr.loc.offset);
         }
 
         bool readInstruction(Reader& reader, Instruction& instr) {
@@ -225,19 +222,50 @@ namespace LOICollection::frontend::ir {
             if (!reader.u8(op) || !reader.i32(operand))
                 return false;
 
-            uint64_t line = 0;
-            uint64_t column = 0;
-            uint64_t offset = 0;
-            if (!reader.u64(line) || !reader.u64(column) || !reader.u64(offset))
-                return false;
-
             if (op > static_cast<uint8_t>(OpCode::LOAD_LEN))
                 return false;
 
             instr.op = static_cast<OpCode>(op);
             instr.operand = operand;
-            instr.loc = SourceLocation(line, column, offset);
             return true;
+        }
+
+        void writeDebugInfo(Writer& writer, const BytecodeChunk& chunk) {
+            for (const auto& instr : chunk.code) {
+                writer.u64(instr.loc.line);
+                writer.u64(instr.loc.column);
+                writer.u64(instr.loc.offset);
+            }
+
+            for (const auto& body : chunk.methodBodies)
+                writeDebugInfo(writer, *body);
+        }
+
+        bool readDebugInfo(Reader& reader, BytecodeChunk& chunk) {
+            for (auto& instr : chunk.code) {
+                uint64_t line = 0;
+                uint64_t column = 0;
+                uint64_t offset = 0;
+
+                if (!reader.u64(line) || !reader.u64(column) || !reader.u64(offset))
+                    return false;
+
+                instr.loc = SourceLocation(line, column, offset);
+            }
+
+            for (auto& body : chunk.methodBodies)
+                if (!readDebugInfo(reader, *body))
+                    return false;
+
+            return true;
+        }
+
+        size_t countInstructions(const BytecodeChunk& chunk) {
+            size_t total = chunk.code.size();
+            for (const auto& body : chunk.methodBodies)
+                total += countInstructions(*body);
+
+            return total;
         }
 
         void writeFuncMeta(Writer& writer, const FuncMeta& meta) {
@@ -360,7 +388,6 @@ namespace LOICollection::frontend::ir {
 
         void writeMethodMeta(Writer& writer, const MethodMeta& meta) {
             writer.str(meta.name);
-            writeStrings(writer, meta.paramNames);
             writer.i32(meta.argCount);
             writer.i32(meta.classIndex);
             writer.i32(meta.bodyIndex);
@@ -368,7 +395,6 @@ namespace LOICollection::frontend::ir {
 
         bool readMethodMeta(Reader& reader, MethodMeta& meta) {
             return reader.str(meta.name)
-                && readStrings(reader, meta.paramNames)
                 && reader.i32(meta.argCount)
                 && reader.i32(meta.classIndex)
                 && reader.i32(meta.bodyIndex);
@@ -412,11 +438,11 @@ namespace LOICollection::frontend::ir {
         void writeLambdaMeta(Writer& writer, const LambdaMeta& meta) {
             writer.i32(meta.bodyIndex);
             writer.i32(meta.argCount);
-            writeStrings(writer, meta.paramNames);
+            writer.i32(meta.captureCount);
         }
 
         bool readLambdaMeta(Reader& reader, LambdaMeta& meta) {
-            return reader.i32(meta.bodyIndex) && reader.i32(meta.argCount) && readStrings(reader, meta.paramNames);
+            return reader.i32(meta.bodyIndex) && reader.i32(meta.argCount) && reader.i32(meta.captureCount);
         }
 
         bool writeChunk(Writer& writer, const BytecodeChunk& chunk) {
@@ -452,6 +478,8 @@ namespace LOICollection::frontend::ir {
             writeVector<LambdaMeta>(writer, chunk.lambdas, [](Writer& w, const LambdaMeta& meta) {
                 writeLambdaMeta(w, meta);
             });
+
+            writer.i32(chunk.slotCount);
 
             writer.u32(static_cast<uint32_t>(chunk.methodBodies.size()));
             for (const auto& body : chunk.methodBodies)
@@ -489,7 +517,11 @@ namespace LOICollection::frontend::ir {
                 })
                 && readVector<LambdaMeta>(reader, chunk.lambdas, [](Reader& r, LambdaMeta& meta) -> bool {
                     return readLambdaMeta(r, meta);
-                })))
+                })
+                && reader.i32(chunk.slotCount)))
+                return false;
+
+            if (chunk.slotCount < 0)
                 return false;
 
             uint32_t bodyCount = 0;
@@ -509,7 +541,9 @@ namespace LOICollection::frontend::ir {
         }
     }
 
-    std::optional<std::string> BytecodeSerializer::serialize(const BytecodeChunk& chunk, const Header& header) {
+    std::optional<std::string> BytecodeSerializer::serialize(
+        const BytecodeChunk& chunk, const Header& header, std::string* bodyChecksum
+    ) {
         Writer payload;
         if (!writeChunk(payload, chunk))
             return std::nullopt;
@@ -528,10 +562,15 @@ namespace LOICollection::frontend::ir {
         writer.raw(checksum.data(), checksum.size());
         writer.raw(body.data(), body.size());
 
+        if (bodyChecksum)
+            *bodyChecksum = checksum;
+
         return writer.take();
     }
 
-    std::optional<BytecodeChunk> BytecodeSerializer::deserialize(const std::string& blob, const Header& expected) {
+    std::optional<BytecodeChunk> BytecodeSerializer::deserialize(
+        const std::string& blob, const Header& expected, std::string* bodyChecksum
+    ) {
         Reader reader(blob);
 
         char magic[sizeof(MAGIC)] = {};
@@ -565,10 +604,54 @@ namespace LOICollection::frontend::ir {
         if (utils::Sha256::compute(body) != checksum)
             return std::nullopt;
 
+        if (bodyChecksum)
+            *bodyChecksum = checksum;
+
         BytecodeChunk chunk;
         if (!readChunk(reader, chunk) || !reader.done())
             return std::nullopt;
 
         return chunk;
+    }
+
+    std::optional<std::string> BytecodeSerializer::serializeDebugInfo(
+        const BytecodeChunk& chunk, const std::string& bodyChecksum
+    ) {
+        if (bodyChecksum.size() != kDigestSize)
+            return std::nullopt;
+
+        Writer writer;
+
+        writer.raw(DEBUG_MAGIC, sizeof(DEBUG_MAGIC));
+        writer.u32(FORMAT_VERSION);
+        writer.raw(bodyChecksum.data(), bodyChecksum.size());
+        writer.u64(countInstructions(chunk));
+        writeDebugInfo(writer, chunk);
+
+        return writer.take();
+    }
+
+    bool BytecodeSerializer::attachDebugInfo(
+        BytecodeChunk& chunk, const std::string& debugBlob, const std::string& bodyChecksum
+    ) {
+        Reader reader(debugBlob);
+
+        char magic[sizeof(DEBUG_MAGIC)] = {};
+        uint32_t version = 0;
+        if (!reader.raw(magic, sizeof(magic)) || std::memcmp(magic, DEBUG_MAGIC, sizeof(DEBUG_MAGIC)) != 0)
+            return false;
+
+        if (!reader.u32(version) || version != FORMAT_VERSION)
+            return false;
+
+        std::string checksum(bodyChecksum.size(), '\0');
+        if (checksum.empty() || !reader.raw(checksum.data(), checksum.size()) || checksum != bodyChecksum)
+            return false;
+
+        uint64_t count = 0;
+        if (!reader.u64(count) || count != countInstructions(chunk))
+            return false;
+
+        return readDebugInfo(reader, chunk) && reader.done();
     }
 }

--- a/src/LOICollectionA/frontend/ir/BytecodeSerializer.h
+++ b/src/LOICollectionA/frontend/ir/BytecodeSerializer.h
@@ -18,17 +18,26 @@ namespace LOICollection::frontend::ir {
         };
 
         LOICOLLECTION_A_NDAPI static std::optional<std::string> serialize(
-            const BytecodeChunk& chunk, const Header& header
+            const BytecodeChunk& chunk, const Header& header, std::string* bodyChecksum = nullptr
         );
 
         LOICOLLECTION_A_NDAPI static std::optional<BytecodeChunk> deserialize(
-            const std::string& blob, const Header& expected
+            const std::string& blob, const Header& expected, std::string* bodyChecksum = nullptr
+        );
+
+        LOICOLLECTION_A_NDAPI static std::optional<std::string> serializeDebugInfo(
+            const BytecodeChunk& chunk, const std::string& bodyChecksum
+        );
+
+        LOICOLLECTION_A_NDAPI static bool attachDebugInfo(
+            BytecodeChunk& chunk, const std::string& debugBlob, const std::string& bodyChecksum
         );
 
     private:
         BytecodeSerializer() = default;
 
         static constexpr char MAGIC[4] = { 'L', 'C', 'U', 'I' };
-        static constexpr uint32_t FORMAT_VERSION = 3;
+        static constexpr char DEBUG_MAGIC[4] = { 'L', 'C', 'U', 'D' };
+        static constexpr uint32_t FORMAT_VERSION = 4;
     };
 }

--- a/src/LOICollectionA/frontend/ir/Compiler.cpp
+++ b/src/LOICollectionA/frontend/ir/Compiler.cpp
@@ -12,9 +12,23 @@
 #include "LOICollectionA/frontend/ir/Compiler.h"
 
 namespace LOICollection::frontend::ir {
+    namespace {
+        std::string qualifiedName(const VariableNode& node) {
+            return node.isStaticField ? node.staticClassName + "::" + node.name : node.name;
+        }
+
+        std::string qualifiedName(const MemberAccessNode& node) {
+            return node.isStaticAccess
+                ? node.staticClassName + "::" + node.memberName
+                : node.memberName;
+        }
+    }
+
     Compiler::Compiler(DiagnosticEngine& diag) : current(std::ref(chunk)), diagnostics(diag) {}
 
     BytecodeChunk Compiler::compile(ASTNode& root) {
+        this->pushScope(false, 0);
+
         if (root.getType() == ASTNode::Type::Program) {
             auto& program = static_cast<ProgramNode&>(root);
 
@@ -81,6 +95,8 @@ namespace LOICollection::frontend::ir {
 
         this->current.get().emit(OpCode::HALT);
 
+        this->chunk.slotCount = this->closeScope();
+
         return std::move(chunk);
     }
 
@@ -101,10 +117,7 @@ namespace LOICollection::frontend::ir {
     }
 
     void Compiler::visit(VariableNode& node) {
-        int idx = node.isStaticField
-            ? this->addConstant(node.staticClassName + "::" + node.name)
-            : this->addConstant(node.name);
-        this->current.get().emit(OpCode::LOAD_VAR, idx, node.loc);
+        this->emitLoad(qualifiedName(node), node.loc);
 
         if (node.type.kind == TypeKind::Optional && !node.preserveOptional)
             this->current.get().emit(OpCode::UNWRAP, 0, node.loc);
@@ -123,17 +136,13 @@ namespace LOICollection::frontend::ir {
         switch (node.target->getType()) {
             case ASTNode::Type::Variable: {
                 auto& var = static_cast<VariableNode&>(*node.target);
-                int idx = var.isStaticField
-                    ? this->addConstant(var.staticClassName + "::" + var.name)
-                    : this->addConstant(var.name);
-                this->current.get().emit(OpCode::STORE_VAR, idx, node.loc);
+                this->emitStore(qualifiedName(var), node.loc);
                 break;
             }
             case ASTNode::Type::MemberAccess: {
                 auto& member = static_cast<MemberAccessNode&>(*node.target);
                 if (member.isStaticAccess) {
-                    int idx = this->addConstant(member.staticClassName + "::" + member.memberName);
-                    this->current.get().emit(OpCode::STORE_VAR, idx, node.loc);
+                    this->emitStore(qualifiedName(member), node.loc);
                     break;
                 }
 
@@ -160,11 +169,9 @@ namespace LOICollection::frontend::ir {
         switch (node.target->getType()) {
             case ASTNode::Type::Variable: {
                 auto& var = static_cast<VariableNode&>(*node.target);
-                int idx = var.isStaticField
-                    ? this->addConstant(var.staticClassName + "::" + var.name)
-                    : this->addConstant(var.name);
+                const std::string name = qualifiedName(var);
 
-                this->current.get().emit(OpCode::LOAD_VAR, idx, node.loc);
+                this->emitLoad(name, node.loc);
                 if (var.type.kind == TypeKind::Optional && !var.preserveOptional)
                     this->current.get().emit(OpCode::UNWRAP, 0, node.loc);
 
@@ -172,15 +179,15 @@ namespace LOICollection::frontend::ir {
                 this->emitArithmeticOp(node.op, node.loc);
 
                 this->current.get().emit(OpCode::DUP, 0, node.loc);
-                this->current.get().emit(OpCode::STORE_VAR, idx, node.loc);
+                this->emitStore(name, node.loc);
                 break;
             }
             case ASTNode::Type::MemberAccess: {
                 auto& member = static_cast<MemberAccessNode&>(*node.target);
                 if (member.isStaticAccess) {
-                    int idx = this->addConstant(member.staticClassName + "::" + member.memberName);
+                    const std::string name = qualifiedName(member);
 
-                    this->current.get().emit(OpCode::LOAD_VAR, idx, node.loc);
+                    this->emitLoad(name, node.loc);
                     if (member.type.kind == TypeKind::Optional && !member.preserveOptional)
                         this->current.get().emit(OpCode::UNWRAP, 0, node.loc);
 
@@ -188,7 +195,7 @@ namespace LOICollection::frontend::ir {
                     this->emitArithmeticOp(node.op, node.loc);
 
                     this->current.get().emit(OpCode::DUP, 0, node.loc);
-                    this->current.get().emit(OpCode::STORE_VAR, idx, node.loc);
+                    this->emitStore(name, node.loc);
                     break;
                 }
 
@@ -265,30 +272,22 @@ namespace LOICollection::frontend::ir {
     }
 
     void Compiler::compileForInArray(ForInNode& node, size_t uid) {
-        int seqIdx = this->addConstant("__forin_seq_" + std::to_string(uid));
-        int idxIdx = this->addConstant("__forin_idx_" + std::to_string(uid));
-
-        /* Loop variables live in the frame's locals so each iteration rebinds
-         * them: a lambda created inside the body snapshots the current value
-         * instead of following a shared slot after the loop ends. */
-        int elemIdx = this->addConstant(node.elementVar);
-        this->current.get().emit(OpCode::DECLARE_LOCAL, elemIdx, node.loc);
-        if (node.hasIndexVar) {
-            int indexVarIdx = this->addConstant(node.indexVar);
-            this->current.get().emit(OpCode::DECLARE_LOCAL, indexVarIdx, node.loc);
-        }
+        const int seqSlot = this->declareSlot("__forin_seq_" + std::to_string(uid));
+        const int idxSlot = this->declareSlot("__forin_idx_" + std::to_string(uid));
+        const int elemSlot = this->declareSlot(node.elementVar);
+        const int indexSlot = node.hasIndexVar ? this->declareSlot(node.indexVar) : -1;
 
         this->compileValue(*node.iterable, node.loc);
-        this->current.get().emit(OpCode::STORE_VAR, seqIdx, node.loc);
+        this->current.get().emit(OpCode::STORE_SLOT, seqSlot, node.loc);
 
         int zeroIdx = this->addConstant(0);
         this->current.get().emit(OpCode::PUSH_INT, zeroIdx, node.loc);
-        this->current.get().emit(OpCode::STORE_VAR, idxIdx, node.loc);
+        this->current.get().emit(OpCode::STORE_SLOT, idxSlot, node.loc);
 
         size_t loopStart = this->current.get().currentIP();
 
-        this->current.get().emit(OpCode::LOAD_VAR, idxIdx, node.loc);
-        this->current.get().emit(OpCode::LOAD_VAR, seqIdx, node.loc);
+        this->current.get().emit(OpCode::LOAD_SLOT, idxSlot, node.loc);
+        this->current.get().emit(OpCode::LOAD_SLOT, seqSlot, node.loc);
         this->current.get().emit(OpCode::LOAD_LEN, 0, node.loc);
         this->current.get().emit(OpCode::CMP_LT, 0, node.loc);
 
@@ -297,22 +296,21 @@ namespace LOICollection::frontend::ir {
         this->loopStack.push_back(LoopContext{});
         this->loopStack.back().continueTarget = loopStart;
 
-        this->current.get().emit(OpCode::LOAD_VAR, seqIdx, node.loc);
-        this->current.get().emit(OpCode::LOAD_VAR, idxIdx, node.loc);
+        this->current.get().emit(OpCode::LOAD_SLOT, seqSlot, node.loc);
+        this->current.get().emit(OpCode::LOAD_SLOT, idxSlot, node.loc);
         this->current.get().emit(OpCode::LOAD_INDEX, 0, node.loc);
-        this->current.get().emit(OpCode::STORE_VAR, elemIdx, node.loc);
+        this->current.get().emit(OpCode::STORE_SLOT, elemSlot, node.loc);
 
-        if (node.hasIndexVar) {
-            int indexVarIdx = this->addConstant(node.indexVar);
-            this->current.get().emit(OpCode::LOAD_VAR, idxIdx, node.loc);
-            this->current.get().emit(OpCode::STORE_VAR, indexVarIdx, node.loc);
+        if (indexSlot >= 0) {
+            this->current.get().emit(OpCode::LOAD_SLOT, idxSlot, node.loc);
+            this->current.get().emit(OpCode::STORE_SLOT, indexSlot, node.loc);
         }
 
         int oneIdx = this->addConstant(1);
-        this->current.get().emit(OpCode::LOAD_VAR, idxIdx, node.loc);
+        this->current.get().emit(OpCode::LOAD_SLOT, idxSlot, node.loc);
         this->current.get().emit(OpCode::PUSH_INT, oneIdx, node.loc);
         this->current.get().emit(OpCode::ADD, 0, node.loc);
-        this->current.get().emit(OpCode::STORE_VAR, idxIdx, node.loc);
+        this->current.get().emit(OpCode::STORE_SLOT, idxSlot, node.loc);
 
         node.body->accept(*this);
         this->current.get().emit(OpCode::POP, 0, node.loc);
@@ -337,26 +335,20 @@ namespace LOICollection::frontend::ir {
     void Compiler::compileForInRange(ForInNode& node, size_t uid) {
         auto& range = static_cast<RangeNode&>(*node.iterable);
 
-        int idxIdx = this->addConstant("__forin_idx_" + std::to_string(uid));
-        int endIdx = this->addConstant("__forin_end_" + std::to_string(uid));
-        int dirIdx = this->addConstant("__forin_dir_" + std::to_string(uid));
-
-        /* Same per-iteration binding as the array form: see compileForInArray. */
-        int elemIdx = this->addConstant(node.elementVar);
-        this->current.get().emit(OpCode::DECLARE_LOCAL, elemIdx, node.loc);
-        if (node.hasIndexVar) {
-            int indexVarIdx = this->addConstant(node.indexVar);
-            this->current.get().emit(OpCode::DECLARE_LOCAL, indexVarIdx, node.loc);
-        }
+        const int idxSlot = this->declareSlot("__forin_idx_" + std::to_string(uid));
+        const int endSlot = this->declareSlot("__forin_end_" + std::to_string(uid));
+        const int dirSlot = this->declareSlot("__forin_dir_" + std::to_string(uid));
+        const int elemSlot = this->declareSlot(node.elementVar);
+        const int indexSlot = node.hasIndexVar ? this->declareSlot(node.indexVar) : -1;
 
         this->compileValue(*range.start, node.loc);
-        this->current.get().emit(OpCode::STORE_VAR, idxIdx, node.loc);
+        this->current.get().emit(OpCode::STORE_SLOT, idxSlot, node.loc);
 
         this->compileValue(*range.end, node.loc);
-        this->current.get().emit(OpCode::STORE_VAR, endIdx, node.loc);
+        this->current.get().emit(OpCode::STORE_SLOT, endSlot, node.loc);
 
-        this->current.get().emit(OpCode::LOAD_VAR, idxIdx, node.loc);
-        this->current.get().emit(OpCode::LOAD_VAR, endIdx, node.loc);
+        this->current.get().emit(OpCode::LOAD_SLOT, idxSlot, node.loc);
+        this->current.get().emit(OpCode::LOAD_SLOT, endSlot, node.loc);
         this->current.get().emit(OpCode::CMP_LE, 0, node.loc);
 
         size_t jmpDescIdx = this->current.get().emit(OpCode::JMP_IF_FALSE, 0, node.loc);
@@ -375,14 +367,14 @@ namespace LOICollection::frontend::ir {
         int dirEndPos = static_cast<int>(this->current.get().currentIP());
         this->current.get().patchJump(jmpDirEndIdx, dirEndPos - static_cast<int>(jmpDirEndIdx) - 1);
 
-        this->current.get().emit(OpCode::STORE_VAR, dirIdx, node.loc);
+        this->current.get().emit(OpCode::STORE_SLOT, dirSlot, node.loc);
 
         size_t loopStart = this->current.get().currentIP();
 
-        this->current.get().emit(OpCode::LOAD_VAR, idxIdx, node.loc);
-        this->current.get().emit(OpCode::LOAD_VAR, endIdx, node.loc);
+        this->current.get().emit(OpCode::LOAD_SLOT, idxSlot, node.loc);
+        this->current.get().emit(OpCode::LOAD_SLOT, endSlot, node.loc);
         this->current.get().emit(OpCode::SUB, 0, node.loc);
-        this->current.get().emit(OpCode::LOAD_VAR, dirIdx, node.loc);
+        this->current.get().emit(OpCode::LOAD_SLOT, dirSlot, node.loc);
         this->current.get().emit(OpCode::MUL, 0, node.loc);
         int zeroIdx = this->addConstant(0);
         this->current.get().emit(OpCode::PUSH_INT, zeroIdx, node.loc);
@@ -393,19 +385,18 @@ namespace LOICollection::frontend::ir {
         this->loopStack.push_back(LoopContext{});
         this->loopStack.back().continueTarget = loopStart;
 
-        this->current.get().emit(OpCode::LOAD_VAR, idxIdx, node.loc);
-        this->current.get().emit(OpCode::STORE_VAR, elemIdx, node.loc);
+        this->current.get().emit(OpCode::LOAD_SLOT, idxSlot, node.loc);
+        this->current.get().emit(OpCode::STORE_SLOT, elemSlot, node.loc);
 
-        if (node.hasIndexVar) {
-            int indexVarIdx = this->addConstant(node.indexVar);
-            this->current.get().emit(OpCode::LOAD_VAR, idxIdx, node.loc);
-            this->current.get().emit(OpCode::STORE_VAR, indexVarIdx, node.loc);
+        if (indexSlot >= 0) {
+            this->current.get().emit(OpCode::LOAD_SLOT, idxSlot, node.loc);
+            this->current.get().emit(OpCode::STORE_SLOT, indexSlot, node.loc);
         }
 
-        this->current.get().emit(OpCode::LOAD_VAR, idxIdx, node.loc);
-        this->current.get().emit(OpCode::LOAD_VAR, dirIdx, node.loc);
+        this->current.get().emit(OpCode::LOAD_SLOT, idxSlot, node.loc);
+        this->current.get().emit(OpCode::LOAD_SLOT, dirSlot, node.loc);
         this->current.get().emit(OpCode::ADD, 0, node.loc);
-        this->current.get().emit(OpCode::STORE_VAR, idxIdx, node.loc);
+        this->current.get().emit(OpCode::STORE_SLOT, idxSlot, node.loc);
 
         node.body->accept(*this);
         this->current.get().emit(OpCode::POP, 0, node.loc);
@@ -845,14 +836,18 @@ namespace LOICollection::frontend::ir {
             mm.name = method.name;
             mm.classIndex = classIdx;
             mm.argCount = static_cast<int>(method.params.size());
-            for (const auto& param : method.params)
-                mm.paramNames.push_back(param.name);
 
             int bodyIdx = static_cast<int>(this->chunk.methodBodies.size());
-            this->chunk.methodBodies.push_back(std::make_unique<BytecodeChunk>());
+            auto body = std::make_unique<BytecodeChunk>();
+            BytecodeChunk& bodyChunk = *body;
+            this->chunk.methodBodies.push_back(std::move(body));
 
             std::reference_wrapper<BytecodeChunk> saved = this->current;
-            this->current = std::ref(*chunk.methodBodies.back());
+            this->current = std::ref(bodyChunk);
+
+            this->pushScope(true, 0);
+            for (const auto& param : method.params)
+                this->declareSlot(param.name);
 
             if (method.isConstructor && !node.baseClassName.empty() && !method.hasSuperCall) {
                 int ctorIdx = -1;
@@ -884,6 +879,8 @@ namespace LOICollection::frontend::ir {
             this->current.get().emit(OpCode::RETURN);
 
             this->current = saved;
+            bodyChunk.slotCount = this->closeScope();
+
             mm.bodyIndex = bodyIdx;
 
             this->chunk.methods.push_back(std::move(mm));
@@ -929,15 +926,17 @@ namespace LOICollection::frontend::ir {
 
     void Compiler::compileDeclarativeBlock(BlockNode& block, const std::string& receiverName) {
         std::string receiver = receiverName;
-        if (receiver.empty())
+        int receiverSlot = -1;
+
+        if (receiver.empty()) {
             receiver = ".form" + std::to_string(this->declarativeCounter++);
+            receiverSlot = this->declareSlot(receiver);
+        }
 
-        int receiverIdx = this->addConstant(receiver);
-
-        if (receiverName.empty())
-            this->current.get().emit(OpCode::DECLARE_LOCAL, receiverIdx);
-
-        this->current.get().emit(OpCode::STORE_VAR, receiverIdx);
+        if (receiverSlot >= 0)
+            this->current.get().emit(OpCode::STORE_SLOT, receiverSlot);
+        else
+            this->emitStore(receiver, {});
 
         for (auto& part : block.parts)
             this->desugarDeclarativeStatements(part, receiver);
@@ -953,7 +952,10 @@ namespace LOICollection::frontend::ir {
                 this->current.get().emit(OpCode::POP);
         }
 
-        this->current.get().emit(OpCode::LOAD_VAR, receiverIdx);
+        if (receiverSlot >= 0)
+            this->current.get().emit(OpCode::LOAD_SLOT, receiverSlot);
+        else
+            this->emitLoad(receiver, {});
     }
 
     void Compiler::desugarDeclarativeStatements(std::unique_ptr<ASTNode>& node, const std::string& receiver) {
@@ -1014,8 +1016,7 @@ namespace LOICollection::frontend::ir {
 
     void Compiler::visit(MemberAccessNode& node) {
         if (node.isStaticAccess) {
-            int idx = this->addConstant(node.staticClassName + "::" + node.memberName);
-            this->current.get().emit(OpCode::LOAD_VAR, idx, node.loc);
+            this->emitLoad(qualifiedName(node), node.loc);
 
             if (node.type.kind == TypeKind::Optional && !node.preserveOptional)
                 this->current.get().emit(OpCode::UNWRAP, 0, node.loc);
@@ -1226,14 +1227,18 @@ namespace LOICollection::frontend::ir {
         mm.name = node.name;
         mm.classIndex = -1;
         mm.argCount = static_cast<int>(node.decl.params.size());
-        for (const auto& param : node.decl.params)
-            mm.paramNames.push_back(param.name);
 
         int bodyIdx = static_cast<int>(this->chunk.methodBodies.size());
-        this->chunk.methodBodies.push_back(std::make_unique<BytecodeChunk>());
+        auto body = std::make_unique<BytecodeChunk>();
+        BytecodeChunk& bodyChunk = *body;
+        this->chunk.methodBodies.push_back(std::move(body));
 
         std::reference_wrapper<BytecodeChunk> saved = this->current;
-        this->current = std::ref(*this->chunk.methodBodies.back());
+        this->current = std::ref(bodyChunk);
+
+        this->pushScope(false, 0);
+        for (const auto& param : node.decl.params)
+            this->declareSlot(param.name);
 
         if (node.decl.body)
             node.decl.body->accept(*this);
@@ -1245,6 +1250,8 @@ namespace LOICollection::frontend::ir {
         this->current.get().emit(OpCode::RETURN);
 
         this->current = saved;
+        bodyChunk.slotCount = this->closeScope();
+
         mm.bodyIndex = bodyIdx;
 
         this->chunk.methods.push_back(std::move(mm));
@@ -1274,8 +1281,7 @@ namespace LOICollection::frontend::ir {
         }
 
         if (node.isCallable) {
-            int idx = this->addConstant(node.resolvedName);
-            this->current.get().emit(OpCode::LOAD_VAR, idx, node.loc);
+            this->emitLoad(node.resolvedName, node.loc);
 
             int argCount = static_cast<int>(node.args.size());
             this->current.get().emit(OpCode::CALL_LAMBDA, argCount, node.loc);
@@ -1294,10 +1300,16 @@ namespace LOICollection::frontend::ir {
 
     void Compiler::visit(LambdaNode& node) {
         int bodyIdx = static_cast<int>(this->chunk.methodBodies.size());
-        this->chunk.methodBodies.push_back(std::make_unique<BytecodeChunk>());
+        auto body = std::make_unique<BytecodeChunk>();
+        BytecodeChunk& bodyChunk = *body;
+        this->chunk.methodBodies.push_back(std::move(body));
 
         std::reference_wrapper<BytecodeChunk> saved = this->current;
-        this->current = std::ref(*this->chunk.methodBodies.back());
+        this->current = std::ref(bodyChunk);
+
+        this->pushScope(false, this->scopes.back().next, true);
+        for (const auto& param : node.decl.params)
+            this->declareSlot(param.name);
 
         if (node.decl.body)
             node.decl.body->accept(*this);
@@ -1310,12 +1322,10 @@ namespace LOICollection::frontend::ir {
 
         this->current = saved;
 
-        std::vector<std::string> paramNames;
-        paramNames.reserve(node.decl.params.size());
-        for (const auto& param : node.decl.params)
-            paramNames.push_back(param.name);
+        const int captureCount = this->scopes.back().base;
+        bodyChunk.slotCount = this->closeScope();
 
-        int lambdaIdx = this->addLambda(bodyIdx, static_cast<int>(node.decl.params.size()), paramNames);
+        int lambdaIdx = this->addLambda(bodyIdx, static_cast<int>(node.decl.params.size()), captureCount);
         this->current.get().emit(OpCode::MAKE_LAMBDA, lambdaIdx, node.loc);
     }
 
@@ -1345,8 +1355,8 @@ namespace LOICollection::frontend::ir {
         return static_cast<int>(this->current.get().macros.size() - 1);
     }
 
-    int Compiler::addLambda(int bodyIndex, int argCount, const std::vector<std::string>& paramNames) {
-        this->current.get().lambdas.push_back({bodyIndex, argCount, paramNames});
+    int Compiler::addLambda(int bodyIndex, int argCount, int captureCount) {
+        this->current.get().lambdas.push_back({bodyIndex, argCount, captureCount});
         return static_cast<int>(this->current.get().lambdas.size() - 1);
     }
 
@@ -1358,6 +1368,60 @@ namespace LOICollection::frontend::ir {
     int Compiler::addSuperCall(int constructorIndex, int argCount) {
         this->current.get().superCalls.push_back({constructorIndex, argCount});
         return static_cast<int>(this->current.get().superCalls.size() - 1);
+    }
+
+    void Compiler::pushScope(bool hasThis, int base, bool inherits) {
+        Scope scope;
+        scope.base = base;
+        scope.next = base;
+        scope.hasThis = hasThis || (!this->scopes.empty() && this->scopes.back().hasThis);
+        scope.inherits = inherits;
+        this->scopes.push_back(std::move(scope));
+    }
+
+    int Compiler::closeScope() {
+        const int slotCount = this->scopes.back().next;
+        this->scopes.pop_back();
+        return slotCount;
+    }
+
+    int Compiler::declareSlot(const std::string& name) {
+        Scope& scope = this->scopes.back();
+        auto [it, inserted] = scope.slots.emplace(name, scope.next);
+        if (inserted)
+            ++scope.next;
+
+        return it->second;
+    }
+
+    std::optional<int> Compiler::resolveSlot(const std::string& name) const {
+        for (auto scope = this->scopes.rbegin(); scope != this->scopes.rend(); ++scope) {
+            if (auto it = scope->slots.find(name); it != scope->slots.end())
+                return it->second;
+
+            if (!scope->inherits)
+                break;
+        }
+
+        return std::nullopt;
+    }
+
+    void Compiler::emitLoad(const std::string& name, const SourceLocation& loc) {
+        if (auto slot = this->resolveSlot(name)) {
+            this->current.get().emit(OpCode::LOAD_SLOT, *slot, loc);
+            return;
+        }
+
+        this->current.get().emit(OpCode::LOAD_VAR, this->addConstant(name), loc);
+    }
+
+    void Compiler::emitStore(const std::string& name, const SourceLocation& loc) {
+        if (auto slot = this->resolveSlot(name)) {
+            this->current.get().emit(OpCode::STORE_SLOT, *slot, loc);
+            return;
+        }
+
+        this->current.get().emit(OpCode::STORE_VAR, this->addConstant(name), loc);
     }
 
     std::string Compiler::methodSignature(const MethodDecl& method) const {

--- a/src/LOICollectionA/frontend/ir/Compiler.h
+++ b/src/LOICollectionA/frontend/ir/Compiler.h
@@ -45,6 +45,17 @@ namespace LOICollection::frontend::ir {
 
         std::vector<LoopContext> loopStack;
 
+        struct Scope {
+            std::unordered_map<std::string, int> slots;
+
+            int base = 0;
+            int next = 0;
+            bool hasThis = false;
+            bool inherits = false;
+        };
+
+        std::vector<Scope> scopes;
+
         size_t methodCount = 0;
         size_t forInCounter = 0;
         size_t declarativeCounter = 0;
@@ -107,10 +118,18 @@ namespace LOICollection::frontend::ir {
         int addConstant(const ValueNode::ValueType& val);
         int addFunction(const std::string& name, int argCount);
         int addMacro(const std::string& name, int argCount);
-        int addLambda(int bodyIndex, int argCount, const std::vector<std::string>& paramNames);
+        int addLambda(int bodyIndex, int argCount, int captureCount);
         int addVirtualCall(int classIndex, int ordinal, int argCount);
         int addSuperCall(int constructorIndex, int argCount);
 
         [[nodiscard]] std::string methodSignature(const MethodDecl& method) const;
+
+        void pushScope(bool hasThis, int base, bool inherits = false);
+        int closeScope();
+        int declareSlot(const std::string& name);
+        [[nodiscard]] std::optional<int> resolveSlot(const std::string& name) const;
+
+        void emitLoad(const std::string& name, const SourceLocation& loc);
+        void emitStore(const std::string& name, const SourceLocation& loc);
     };
 }

--- a/src/LOICollectionA/frontend/ir/OpCode.h
+++ b/src/LOICollectionA/frontend/ir/OpCode.h
@@ -7,7 +7,8 @@ namespace LOICollection::frontend::ir {
         PUSH_INT, PUSH_FLOAT, PUSH_STR, PUSH_BOOL, PUSH_NONE,
         POP, DUP, DUP2, ROT3, SWAP2, UNWRAP, TYPE_OF, HAS_VALUE, IS_NONE,
 
-        LOAD_VAR, STORE_VAR, DECLARE_LOCAL,
+        LOAD_VAR, STORE_VAR,
+        LOAD_SLOT, STORE_SLOT,
 
         ADD, SUB, MUL, DIV, MOD, POW,
 
@@ -41,6 +42,7 @@ namespace LOICollection::frontend::ir {
         HALT,
 
         DUP_STORE,
+        DUP_STORE_SLOT,
         DUP_IS_NONE,
         LOAD_LEN
     };

--- a/src/LOICollectionA/frontend/ir/Optimizer.cpp
+++ b/src/LOICollectionA/frontend/ir/Optimizer.cpp
@@ -95,6 +95,10 @@ namespace LOICollection::frontend::ir {
         }
     }
 
+    bool isStoreOp(OpCode op) {
+        return op == OpCode::STORE_VAR || op == OpCode::STORE_SLOT;
+    }
+
     // `kept op identity == kept`, applicable when the kept operand is a known number of a
     // compatible kind. Divided by type-promotion rules: `x / 1` and `x ^ 1` always produce
     // floats, and float `x + 0.0` flips -0.0, so those combinations stay untouched.
@@ -314,11 +318,13 @@ namespace LOICollection::frontend::ir {
         std::vector<bool> dropped(code.size(), false);
         std::vector<StackEntry> stack{ std::monostate{} };
 
-        // Straight-line scalar constants per variable name (the pool may hold the same
-        // name at several indices, so keying by the string is the only stable identity).
-        // Entries are dropped at merge points and around ops that can execute script
-        // code, so a forwarded LOAD_VAR always reproduces the stored value.
-        std::unordered_map<std::string, ValueNode::ValueType> varSlots;
+        std::unordered_map<int, ValueNode::ValueType> slotValues;
+        std::unordered_map<std::string, ValueNode::ValueType> nameValues;
+
+        const auto clearTracked = [&slotValues, &nameValues] {
+            slotValues.clear();
+            nameValues.clear();
+        };
 
         for (size_t i = 0; i < code.size(); ++i) {
             const auto& instr = code[i];
@@ -328,9 +334,9 @@ namespace LOICollection::frontend::ir {
 
             if (targets.contains(oldIdx)) {
                 stack.assign(1, std::monostate{});
-                varSlots.clear();
+                clearTracked();
             } else if (canWriteVariables(instr.op)) {
-                varSlots.clear();
+                clearTracked();
             }
 
             switch (instr.op) {
@@ -482,11 +488,10 @@ namespace LOICollection::frontend::ir {
                     break;
                 }
 
-                case OpCode::LOAD_VAR: {
-                    const std::string& name = std::get<std::string>(chunk.constants[instr.operand]);
-                    auto slot = varSlots.find(name);
+                case OpCode::LOAD_SLOT: {
+                    auto slot = slotValues.find(instr.operand);
 
-                    if (slot != varSlots.end()) {
+                    if (slot != slotValues.end()) {
                         emitPush(chunk, foldedCode, slot->second, instr.loc);
                         emittedAt = static_cast<int>(foldedCode.size()) - 1;
                         stack.emplace_back(TrackedValue{ slot->second, emittedAt, true });
@@ -500,14 +505,61 @@ namespace LOICollection::frontend::ir {
                     break;
                 }
 
+                case OpCode::LOAD_VAR: {
+                    const std::string& name = std::get<std::string>(chunk.constants[instr.operand]);
+                    auto slot = nameValues.find(name);
+
+                    if (slot != nameValues.end()) {
+                        emitPush(chunk, foldedCode, slot->second, instr.loc);
+                        emittedAt = static_cast<int>(foldedCode.size()) - 1;
+                        stack.emplace_back(TrackedValue{ slot->second, emittedAt, true });
+                        stats.folded++;
+                    } else {
+                        emittedAt = static_cast<int>(foldedCode.size());
+                        foldedCode.push_back(instr);
+                        stack.emplace_back(std::monostate{});
+                    }
+
+                    break;
+                }
+
+                case OpCode::STORE_SLOT: {
+                    StackEntry value = popEntry(stack);
+
+                    if (isKnown(value) && isScalarValue(knownValue(value).value))
+                        slotValues[instr.operand] = knownValue(value).value;
+                    else
+                        slotValues.erase(instr.operand);
+
+                    emittedAt = static_cast<int>(foldedCode.size());
+                    foldedCode.push_back(instr);
+
+                    break;
+                }
+
                 case OpCode::STORE_VAR: {
                     StackEntry value = popEntry(stack);
                     const std::string& name = std::get<std::string>(chunk.constants[instr.operand]);
 
                     if (isKnown(value) && isScalarValue(knownValue(value).value))
-                        varSlots[name] = knownValue(value).value;
+                        nameValues[name] = knownValue(value).value;
                     else
-                        varSlots.erase(name);
+                        nameValues.erase(name);
+
+                    emittedAt = static_cast<int>(foldedCode.size());
+                    foldedCode.push_back(instr);
+
+                    break;
+                }
+
+                case OpCode::DUP_STORE_SLOT: {
+                    if (isKnown(stack.back()) && isScalarValue(knownValue(stack.back()).value))
+                        slotValues[instr.operand] = knownValue(stack.back()).value;
+                    else
+                        slotValues.erase(instr.operand);
+
+                    if (auto* known = std::get_if<TrackedValue>(&stack.back()))
+                        known->removable = false;
 
                     emittedAt = static_cast<int>(foldedCode.size());
                     foldedCode.push_back(instr);
@@ -519,9 +571,9 @@ namespace LOICollection::frontend::ir {
                     const std::string& name = std::get<std::string>(chunk.constants[instr.operand]);
 
                     if (isKnown(stack.back()) && isScalarValue(knownValue(stack.back()).value))
-                        varSlots[name] = knownValue(stack.back()).value;
+                        nameValues[name] = knownValue(stack.back()).value;
                     else
-                        varSlots.erase(name);
+                        nameValues.erase(name);
 
                     if (auto* known = std::get_if<TrackedValue>(&stack.back()))
                         known->removable = false;
@@ -548,20 +600,35 @@ namespace LOICollection::frontend::ir {
                 }
 
                 case OpCode::DUP: {
-                    if (i + 1 < code.size() && code[i + 1].op == OpCode::STORE_VAR &&
+                    if (i + 1 < code.size() && isStoreOp(code[i + 1].op) &&
                         !targets.contains(oldIdx) && !targets.contains(oldIdx + 1)) {
                         if (auto* known = std::get_if<TrackedValue>(&stack.back()))
                             known->removable = false;
 
-                        const auto& name =
-                            std::get<std::string>(chunk.constants[code[i + 1].operand]);
-                        if (isKnown(stack.back()) && isScalarValue(knownValue(stack.back()).value))
-                            varSlots[name] = knownValue(stack.back()).value;
-                        else
-                            varSlots.erase(name);
+                        const bool scalar = isKnown(stack.back()) &&
+                            isScalarValue(knownValue(stack.back()).value);
+
+                        if (code[i + 1].op == OpCode::STORE_SLOT) {
+                            if (scalar)
+                                slotValues[code[i + 1].operand] = knownValue(stack.back()).value;
+                            else
+                                slotValues.erase(code[i + 1].operand);
+                        } else {
+                            const auto& name =
+                                std::get<std::string>(chunk.constants[code[i + 1].operand]);
+
+                            if (scalar)
+                                nameValues[name] = knownValue(stack.back()).value;
+                            else
+                                nameValues.erase(name);
+                        }
 
                         emittedAt = static_cast<int>(foldedCode.size());
-                        foldedCode.push_back({ OpCode::DUP_STORE, code[i + 1].operand, instr.loc });
+                        foldedCode.push_back({
+                            code[i + 1].op == OpCode::STORE_SLOT ? OpCode::DUP_STORE_SLOT : OpCode::DUP_STORE,
+                            code[i + 1].operand,
+                            instr.loc
+                        });
                         stats.folded++;
                         skipNext = true;
                         break;

--- a/src/LOICollectionA/frontend/ir/VM.cpp
+++ b/src/LOICollectionA/frontend/ir/VM.cpp
@@ -401,12 +401,6 @@ namespace LOICollection::frontend::ir {
         const std::string& name,
         const ValueNode::ValueType& val
     ) {
-        auto localIt = frame.locals.find(name);
-        if (localIt != frame.locals.end()) {
-            localIt->second = val;
-            return;
-        }
-
         if (frame.hasThis) {
             auto obj = std::get<ObjectRef>(frame.thisObj);
 
@@ -645,14 +639,28 @@ namespace LOICollection::frontend::ir {
                     break;
                 }
 
-                case OpCode::LOAD_VAR: {
-                    const auto& name = std::get<std::string>(cur.constants[instr.operand]);
-
-                    auto localIt = frame.locals.find(name);
-                    if (localIt != frame.locals.end()) {
-                        this->push(localIt->second);
+                case OpCode::LOAD_SLOT: {
+                    if (instr.operand < 0 || static_cast<size_t>(instr.operand) >= frame.locals.size()) {
+                        this->diagnostics.addError(this->currentLoc, "Slot index out of range");
                         break;
                     }
+
+                    this->push(frame.locals[instr.operand]);
+                    break;
+                }
+
+                case OpCode::STORE_SLOT: {
+                    if (instr.operand < 0 || static_cast<size_t>(instr.operand) >= frame.locals.size()) {
+                        this->diagnostics.addError(this->currentLoc, "Slot index out of range");
+                        break;
+                    }
+
+                    frame.locals[instr.operand] = this->pop();
+                    break;
+                }
+
+                case OpCode::LOAD_VAR: {
+                    const auto& name = std::get<std::string>(cur.constants[instr.operand]);
 
                     if (frame.hasThis) {
                         auto obj = std::get<ObjectRef>(frame.thisObj);
@@ -708,21 +716,27 @@ namespace LOICollection::frontend::ir {
                     this->push(globalIt->second);
                     break;
                 }
-                case OpCode::DECLARE_LOCAL: {
-                    /* Pins a for-in loop variable to the current frame so each
-                     * iteration rebinds it; lambdas snapshot frame.locals when
-                     * created, capturing the value of their own iteration. */
-                    const auto& name = std::get<std::string>(cur.constants[instr.operand]);
-                    frame.locals.try_emplace(name, std::monostate{});
-                    break;
-                }
-
                 case OpCode::STORE_VAR: {
                     const auto& name = std::get<std::string>(cur.constants[instr.operand]);
 
                     auto val = this->pop();
 
                     this->storeVariable(chunk, frame, name, val);
+                    break;
+                }
+
+                case OpCode::DUP_STORE_SLOT: {
+                    if (this->stack.empty()) {
+                        this->diagnostics.addError(this->currentLoc, "Stack underflow during DUP_STORE_SLOT");
+                        break;
+                    }
+
+                    if (instr.operand < 0 || static_cast<size_t>(instr.operand) >= frame.locals.size()) {
+                        this->diagnostics.addError(this->currentLoc, "Slot index out of range");
+                        break;
+                    }
+
+                    frame.locals[instr.operand] = this->stack.back();
                     break;
                 }
 
@@ -901,11 +915,13 @@ namespace LOICollection::frontend::ir {
                     func->owner = owner;
                     func->bodyIndex = meta.bodyIndex;
                     func->argCount = meta.argCount;
-                    func->paramNames = meta.paramNames;
                     func->hasThis = frame.hasThis;
                     if (frame.hasThis)
                         func->thisObj = std::get<ObjectRef>(frame.thisObj);
-                    func->captures = frame.locals;
+                    func->captures.assign(
+                        frame.locals.begin(),
+                        frame.locals.begin() + std::min(static_cast<size_t>(meta.captureCount), frame.locals.size())
+                    );
                     func->globals = this->variables;
 
                     this->push(func);
@@ -978,7 +994,7 @@ namespace LOICollection::frontend::ir {
                         callee.pendingPush = obj;
 
                         for (int i = 0; i < ctor.argCount; ++i)
-                            callee.locals[ctor.paramNames[i]] = args[i];
+                            callee.locals[i] = args[i];
 
                         if (!this->pushFrame(std::move(callee)))
                             break;
@@ -1041,7 +1057,7 @@ namespace LOICollection::frontend::ir {
                     callee.thisObj = receiver;
 
                     for (int i = 0; i < meta.argCount; ++i)
-                        callee.locals[meta.paramNames[i]] = args[i];
+                        callee.locals[i] = args[i];
 
                     if (!this->pushFrame(std::move(callee)))
                         break;
@@ -1091,7 +1107,7 @@ namespace LOICollection::frontend::ir {
                     callee.thisObj = receiver;
 
                     for (int i = 0; i < method.argCount; ++i)
-                        callee.locals[method.paramNames[i]] = args[i];
+                        callee.locals[i] = args[i];
 
                     if (!this->pushFrame(std::move(callee)))
                         break;
@@ -1133,7 +1149,7 @@ namespace LOICollection::frontend::ir {
                     callee.thisObj = receiver;
 
                     for (int i = 0; i < ctor.argCount; ++i)
-                        callee.locals[ctor.paramNames[i]] = args[i];
+                        callee.locals[i] = args[i];
 
                     if (!this->pushFrame(std::move(callee)))
                         break;
@@ -1231,7 +1247,7 @@ namespace LOICollection::frontend::ir {
                     callee.hasThis = false;
 
                     for (int i = 0; i < meta.argCount; ++i)
-                        callee.locals[meta.paramNames[i]] = args[i];
+                        callee.locals[i] = args[i];
 
                     if (!this->pushFrame(std::move(callee)))
                         break;
@@ -1268,10 +1284,17 @@ namespace LOICollection::frontend::ir {
                     callee.hasThis = func->hasThis;
                     if (func->hasThis)
                         callee.thisObj = func->thisObj;
-                    callee.locals = func->captures;
+
+                    const size_t paramBase = func->captures.size();
+                    if (paramBase + static_cast<size_t>(func->argCount) > callee.locals.size()) {
+                        this->diagnostics.addError(this->currentLoc, "Lambda frame is too small for its parameters");
+                        break;
+                    }
+
+                    std::copy_n(func->captures.begin(), paramBase, callee.locals.begin());
 
                     for (int i = 0; i < func->argCount; ++i)
-                        callee.locals[func->paramNames[i]] = args[i];
+                        callee.locals[paramBase + i] = args[i];
 
                     if (!this->pushFrame(std::move(callee)))
                         break;
@@ -1561,10 +1584,17 @@ namespace LOICollection::frontend::ir {
         callee.hasThis = func->hasThis;
         if (func->hasThis)
             callee.thisObj = func->thisObj;
-        callee.locals = func->captures;
+
+        const size_t paramBase = func->captures.size();
+        if (paramBase + static_cast<size_t>(func->argCount) > callee.locals.size()) {
+            diagnostics.addError({}, "Lambda frame is too small for its parameters");
+            return std::monostate{};
+        }
+
+        std::copy_n(func->captures.begin(), paramBase, callee.locals.begin());
 
         for (int i = 0; i < func->argCount; ++i)
-            callee.locals[func->paramNames[i]] = args[i];
+            callee.locals[paramBase + i] = args[i];
 
         vm.frames.push_back(std::move(callee));
         return vm.execute(func->owner, placeholders);

--- a/src/LOICollectionA/frontend/ir/VM.h
+++ b/src/LOICollectionA/frontend/ir/VM.h
@@ -48,15 +48,16 @@ namespace LOICollection::frontend::ir {
             std::reference_wrapper<const BytecodeChunk> chunk;
 
             size_t ip = 0;
-            std::unordered_map<std::string, ValueNode::ValueType> locals;
+            std::vector<ValueNode::ValueType> locals;
 
             ValueNode::ValueType thisObj;
             bool hasThis = false;
-            
+
             ValueNode::ValueType pendingPush;
             bool hasPending = false;
 
-            explicit Frame(const BytecodeChunk& chunkRef) : chunk(chunkRef) {}
+            explicit Frame(const BytecodeChunk& chunkRef)
+                : chunk(chunkRef), locals(chunkRef.slotCount) {}
         };
 
         DiagnosticEngine& diagnostics;

--- a/src/LOICollectionA/modules/form/GUIManager.cpp
+++ b/src/LOICollectionA/modules/form/GUIManager.cpp
@@ -111,7 +111,12 @@ namespace LOICollection::form {
 
         const std::string cachePath = path + ".lcc";
         if (auto blob = this->readFile(cachePath); blob.has_value()) {
-            if (auto chunk = frontend::ir::BytecodeSerializer::deserialize(blob.value(), header)) {
+            std::string bodyChecksum;
+
+            if (auto chunk = frontend::ir::BytecodeSerializer::deserialize(blob.value(), header, &bodyChecksum)) {
+                if (auto debug = this->readFile(cachePath + ".dbg"); debug.has_value())
+                    frontend::ir::BytecodeSerializer::attachDebugInfo(*chunk, debug.value(), bodyChecksum);
+
                 this->mImpl->cache.insert_or_assign(id, std::make_shared<frontend::ir::BytecodeChunk>(std::move(*chunk)));
                 warnIfMissingPermission(id);
                 return {};
@@ -136,10 +141,18 @@ namespace LOICollection::form {
         frontend::ir::Optimizer optimizer;
         optimizer.optimize(*bytecode);
 
-        if (auto blob = frontend::ir::BytecodeSerializer::serialize(*bytecode, header)) {
+        std::string bodyChecksum;
+
+        if (auto blob = frontend::ir::BytecodeSerializer::serialize(*bytecode, header, &bodyChecksum)) {
             std::ofstream out(cachePath, std::ios::binary | std::ios::trunc);
             if (out)
                 out.write(blob->data(), static_cast<std::streamsize>(blob->size()));
+
+            if (auto debug = frontend::ir::BytecodeSerializer::serializeDebugInfo(*bytecode, bodyChecksum)) {
+                std::ofstream debugOut(cachePath + ".dbg", std::ios::binary | std::ios::trunc);
+                if (debugOut)
+                    debugOut.write(debug->data(), static_cast<std::streamsize>(debug->size()));
+            }
         }
 
         this->mImpl->cache.insert_or_assign(id, bytecode);


### PR DESCRIPTION
…decar

Bind function, method, lambda and for-in variables to frame slots at compile time instead of looking them up by name at run time, so the compiled artifact no longer carries those names.

Frame locals become a vector indexed by slot; lambdas keep their captured prefix and lay parameters out after it, which lets a lambda scope resolve outer names through the enclosing scope while function and method scopes stay isolated.

Move each instruction's source position into a separate `.lcc.dbg` file tied to the artifact by its body checksum. The shipped artifact keeps only opcode and operand, cutting it by ~60% on the bundled scripts, and the positions are reattached on load when the sidecar is present.

Bump the bytecode format to 4.