### PR TITLE
fix(frontend): break callback/host retain cycles via receiver-binding

### DIFF
--- a/assets/common/gui/blacklist.lcui
+++ b/assets/common/gui/blacklist.lcui
@@ -19,14 +19,14 @@ open = new CustomForm("blacklist.open", {tr("blacklist.gui.title")}) {
         if (!navigateAdd.value) [
             navigateAdd.value = true;
 
-            open.close();
+            this.close();
         ]
     }, addBlacklistOption);
     button({tr("blacklist.gui.removeBlacklist")}, on: func () -> void {
         if (!navigateDelete.value) [
             navigateDelete.value = true;
 
-            open.close();
+            this.close();
         ]
     }, removeBlacklistOption);
     closeButton();
@@ -72,7 +72,7 @@ add = new PaginatedForm("blacklist.add", {tr("blacklist.gui.add.title")}, GUIMan
 
                         contentValue.value = true;
 
-                        content.close();
+                        this.close();
                     });
                     show(func (result) -> void {
                         if (!contentValue.value) [
@@ -115,7 +115,7 @@ remove = new PaginatedForm("blacklist.remove", {tr("blacklist.gui.remove.title")
 
                         infoRemoved.value = true;
 
-                        info.close();
+                        this.close();
                     });
                     show(func (result) -> void {
                         if (!infoRemoved.value) [

--- a/assets/common/gui/cdk.lcui
+++ b/assets/common/gui/cdk.lcui
@@ -25,21 +25,21 @@ cdkOpen = new CustomForm("cdk.open", {tr("cdk.gui.title")}) {
         if (!navigateNew.value) [
             navigateNew.value = true;
 
-            cdkOpen.close();
+            this.close();
         ]
     }, addCdkOption);
     button({tr("cdk.gui.removeCdk")}, on: func () -> void {
         if (!navigateRemove.value) [
             navigateRemove.value = true;
 
-            cdkOpen.close();
+            this.close();
         ]
     }, removeCdkOption);
     button({tr("cdk.gui.addAward")}, on: func () -> void {
         if (!navigateAward.value) [
             navigateAward.value = true;
 
-            cdkOpen.close();
+            this.close();
         ]
     }, addAwardOption);
     closeButton();
@@ -73,7 +73,7 @@ convert = new CustomForm("cdk.convert", {tr("cdk.gui.title")}) {
     ConfirmBar(saveLabel(), func () -> void {
         GUIManager::callback("cdk.convert.submit", [ cdkInput.getData() ]);
 
-        convert.close();
+        this.close();
     });
     show();
 };
@@ -102,7 +102,7 @@ cdkNew = new CustomForm("cdk.new", {tr("cdk.gui.title")}) {
 
         newDone.value = true;
 
-        cdkNew.close();
+        this.close();
     });
     show(func (result) -> void {
         if (!newDone.value) [
@@ -152,7 +152,7 @@ func buildRemoveInfo(id: string) -> void {
 
             removeDone.value = true;
 
-            removeInfo.close();
+            this.close();
         });
         show(func (result) -> void {
             if (!removeDone.value) [
@@ -183,21 +183,21 @@ func buildAwardInfo(id: string) -> void {
             if (!navigateScore.value) [
                 navigateScore.value = true;
 
-                awardInfo.close();
+                this.close();
             ]
         }, new ButtonOptions());
         button({tr("cdk.gui.award.item")}, on: func () -> void {
             if (!navigateItem.value) [
                 navigateItem.value = true;
 
-                awardInfo.close();
+                this.close();
             ]
         }, new ButtonOptions());
         ConfirmBar({tr("cdk.gui.award.title")}, func () -> void {
             if (!navigateTitle.value) [
                 navigateTitle.value = true;
 
-                awardInfo.close();
+                this.close();
             ]
         });
         show(func (result) -> void {
@@ -245,7 +245,7 @@ func buildAwardScore(id: string) -> void {
 
             scoreDone.value = true;
 
-            awardScore.close();
+            this.close();
         });
         show(func (result) -> void {
             if (!scoreDone.value) [
@@ -271,14 +271,14 @@ func buildAwardItem(id: string) -> void {
             if (!navigateInventory.value) [
                 navigateInventory.value = true;
 
-                awardItem.close();
+                this.close();
             ]
         }, new ButtonOptions());
         ConfirmBar({tr("cdk.gui.award.item.custom")}, func () -> void {
             if (!navigateCustom.value) [
                 navigateCustom.value = true;
 
-                awardItem.close();
+                this.close();
             ]
         });
         show(func (result) -> void {
@@ -321,7 +321,7 @@ func buildItemType(id: string) -> void {
         ConfirmBar(saveLabel(), func () -> void {
             typeDone.value = true;
 
-            itemType.close();
+            this.close();
         });
         show(func (result) -> void {
             if (typeDone.value) [
@@ -376,7 +376,7 @@ func buildItemCommon(id: string, itemType: string) -> void {
 
             itemCommonDone.value = true;
 
-            itemCommon.close();
+            this.close();
         });
         show(func (result) -> void {
             if (!itemCommonDone.value) [
@@ -421,7 +421,7 @@ func buildInventoryConfirm(id: string, slot: int) -> void {
 
             inventoryConfirmDone.value = true;
 
-            inventoryConfirm.close();
+            this.close();
         });
         show(func (result) -> void {
             if (!inventoryConfirmDone.value) [
@@ -456,7 +456,7 @@ func buildAwardTitle(id: string) -> void {
 
             titleDone.value = true;
 
-            awardTitle.close();
+            this.close();
         });
         show(func (result) -> void {
             if (!titleDone.value) [

--- a/assets/common/gui/chat.lcui
+++ b/assets/common/gui/chat.lcui
@@ -19,14 +19,14 @@ manage = new CustomForm("chat.manage", {tr("chat.gui.title")}) {
         if (!navigateAdd.value) [
             navigateAdd.value = true;
 
-            manage.close();
+            this.close();
         ]
     }, addOption);
     button({tr("chat.gui.manager.remove")}, on: func () -> void {
         if (!navigateRemove.value) [
             navigateRemove.value = true;
 
-            manage.close();
+            this.close();
         ]
     }, removeOption);
     closeButton();
@@ -62,14 +62,14 @@ setting = new CustomForm("chat.setting", {tr("chat.gui.title")}) {
         if (!navigateTitle.value) [
             navigateTitle.value = true;
 
-            setting.close();
+            this.close();
         ]
     }, setTitleOption);
     button({tr("chat.gui.setBlacklist")}, on: func () -> void {
         if (!navigateBlacklist.value) [
             navigateBlacklist.value = true;
 
-            setting.close();
+            this.close();
         ]
     }, setBlacklistOption);
     closeButton();
@@ -122,7 +122,7 @@ func buildContentAdd(targetUuid: string) -> void {
             submitResult = GUIManager::request("chat.title.add", [ targetUuid, titleField.getData(), timeField.getData() ]);
 
             submitDone.value = submitResult[0];
-            content.close();
+            this.close();
         });
         show(func (result) -> void {
             if (!submitDone.value) [
@@ -206,7 +206,7 @@ blacklist = new PaginatedForm("chat.blacklist", {tr("chat.gui.title")}, GUIManag
         if (!navigateAddBlacklist.value) [
             navigateAddBlacklist.value = true;
 
-            blacklist.close();
+            this.close();
         ]
     }, blacklistAddOption);
     show(func (result) -> void {
@@ -227,7 +227,7 @@ blacklist = new PaginatedForm("chat.blacklist", {tr("chat.gui.title")}, GUIManag
                     ConfirmBar({tr("chat.gui.setBlacklist.set.remove")}, func () -> void {
                         GUIManager::callback("chat.blacklist.remove", [ result.selection ]);
 
-                        info.close();
+                        this.close();
                     });
                     show(func (result) -> void {
                         GUIManager::open("chat", "chat.blacklist", 3, []);

--- a/assets/common/gui/language.lcui
+++ b/assets/common/gui/language.lcui
@@ -10,7 +10,7 @@ form = new CustomForm("language.gui", {tr("language.gui.title")}) {
     ConfirmBar(saveLabel(), func () -> void {
         GUIManager::callback("language.callback", [ lang.getData() ]);
 
-        form.close();
+        this.close();
     });
     show();
 };

--- a/assets/common/gui/market.lcui
+++ b/assets/common/gui/market.lcui
@@ -71,49 +71,49 @@ marketOpen = new CustomForm("market.open", {tr("market.gui.title")}) {
         if (!navigateBuy.value) [
             navigateBuy.value = true;
 
-            marketOpen.close();
+            this.close();
         ]
     }, worldbuyOption);
     button({tr("market.gui.store")}, on: func () -> void {
         if (!navigateStore.value) [
             navigateStore.value = true;
 
-            marketOpen.close();
+            this.close();
         ]
     }, storeOption);
     button({tr("market.gui.quote")}, on: func () -> void {
         if (!navigateQuote.value) [
             navigateQuote.value = true;
 
-            marketOpen.close();
+            this.close();
         ]
     }, quoteOption);
     button({tr("market.gui.wanted")}, on: func () -> void {
         if (!navigateWanted.value) [
             navigateWanted.value = true;
 
-            marketOpen.close();
+            this.close();
         ]
     }, wantedOption);
     button({tr("market.gui.auction")}, on: func () -> void {
         if (!navigateAuction.value) [
             navigateAuction.value = true;
 
-            marketOpen.close();
+            this.close();
         ]
     }, auctionOption);
     button({tr("market.gui.trade")}, on: func () -> void {
         if (!navigateTrade.value) [
             navigateTrade.value = true;
 
-            marketOpen.close();
+            this.close();
         ]
     }, tradeOption);
     button({tr("market.gui.personal")}, on: func () -> void {
         if (!navigatePersonal.value) [
             navigatePersonal.value = true;
 
-            marketOpen.close();
+            this.close();
         ]
     }, personalOption);
     closeButton();
@@ -220,28 +220,28 @@ marketPersonal = new CustomForm("market.personal", {tr("market.gui.title")}) {
         if (!navigateSellItem.value) [
             navigateSellItem.value = true;
 
-            marketPersonal.close();
+            this.close();
         ]
     }, sellItemOption);
     button({tr("market.gui.personal.sellItemContent")}, on: func () -> void {
         if (!navigateSellContent.value) [
             navigateSellContent.value = true;
 
-            marketPersonal.close();
+            this.close();
         ]
     }, sellItemContentOption);
     button({tr("market.gui.store.mine")}, on: func () -> void {
         if (!navigateStoreMine.value) [
             navigateStoreMine.value = true;
 
-            marketPersonal.close();
+            this.close();
         ]
     }, storeMineOption);
     button({tr("market.gui.personal.blacklist")}, on: func () -> void {
         if (!navigateBlacklist.value) [
             navigateBlacklist.value = true;
 
-            marketPersonal.close();
+            this.close();
         ]
     }, blacklistOption);
     closeButton();
@@ -325,7 +325,7 @@ blacklist = new PaginatedForm("market.blacklist", {tr("market.gui.title")}, GUIM
         if (!navigateBlacklistAdd.value) [
             navigateBlacklistAdd.value = true;
 
-            blacklist.close();
+            this.close();
         ]
     }, blacklistAddOption);
     show(func (result) -> void {
@@ -387,7 +387,7 @@ func buildItemInfo(id: string) -> void {
             buyResult.value = buyResultData[0];
             buyDone.value = true;
 
-            itemInfo.close();
+            this.close();
         }, buyItemOption);
 
         if (GUIManager::request("market.isAdmin", [])[0]) [
@@ -396,7 +396,7 @@ func buildItemInfo(id: string) -> void {
 
                 offshelfDone.value = true;
 
-                itemInfo.close();
+                this.close();
             }, delistItemOption);
         ]
 
@@ -431,7 +431,7 @@ func buildItemContent(id: string) -> void {
 
             offshelfReturnDone.value = true;
 
-            itemMine.close();
+            this.close();
         }, delistItemOption);
         closeButton();
         show(func (result) -> void {
@@ -481,7 +481,7 @@ func buildSellItem(slot: int) -> void {
             sellResult.value = sellResultData[0];
             sellDone.value = true;
 
-            sellItemForm.close();
+            this.close();
         });
         show(func (result) -> void {
             if (!sellDone.value) [
@@ -520,7 +520,7 @@ func buildTradeType(uuid: string) -> void {
         ConfirmBar(saveLabel(), func () -> void {
             typeDone.value = true;
 
-            tradeType.close();
+            this.close();
         });
         show(func (result) -> void {
             if (typeDone.value) [
@@ -552,7 +552,7 @@ func buildBlacklistSet(id: string) -> void {
 
             removeDone.value = true;
 
-            blacklistInfo.close();
+            this.close();
         });
         show(func (result) -> void {
             if (!removeDone.value) [

--- a/assets/common/gui/market_auction.lcui
+++ b/assets/common/gui/market_auction.lcui
@@ -21,14 +21,14 @@ auction = new PaginatedForm("market.auction", {tr("market.gui.title")}, GUIManag
         if (!navigateAuctionCreate.value) [
             navigateAuctionCreate.value = true;
 
-            auction.close();
+            this.close();
         ]
     }, createOption);
     button({tr("market.gui.auction.mine")}, on: func () -> void {
         if (!navigateAuctionMine.value) [
             navigateAuctionMine.value = true;
 
-            auction.close();
+            this.close();
         ]
     }, mineOption);
     closeButton();
@@ -78,7 +78,7 @@ func buildAuctionInfo(id: string) -> void {
             bidResult.value = bidResultData[0];
             bidDone.value = true;
 
-            auctionInfo.close();
+            this.close();
         });
         show(func (result) -> void {
             if (bidDone.value) [
@@ -150,7 +150,7 @@ func buildAuctionCreate(slot: int) -> void {
             createResult.value = createResultData[0];
             createDone.value = true;
 
-            auctionCreate.close();
+            this.close();
         });
         show(func (result) -> void {
             if (createDone.value) [

--- a/assets/common/gui/market_store.lcui
+++ b/assets/common/gui/market_store.lcui
@@ -51,25 +51,25 @@ mineForm = new CustomForm("market.store.mine", {tr("market.gui.title")}) {
         if (checkData[0]) [
             navigateUpload.value = true;
 
-            mineForm.close();
+            this.close();
         ]
     }, uploadOption);
     button({tr("market.gui.store.mine.manage")}, on: func () -> void {
         navigateManage.value = true;
 
-        mineForm.close();
+        this.close();
     }, manageOption);
     button({tr("market.gui.store.mine.dissolve")}, on: func () -> void {
         navigateDissolve.value = true;
 
-        mineForm.close();
+        this.close();
     }, dissolveOption);
 
     if (GUIManager::request("market.isAdmin", [])[0] && GUIManager::request("market.store.review.enabled", [])[0]) [
         button({tr("market.gui.store.mine.audit")}, on: func () -> void {
             navigateAudit.value = true;
 
-            mineForm.close();
+            this.close();
         }, auditOption);
     ]
 
@@ -132,7 +132,7 @@ createForm = new CustomForm("market.store.create", {tr("market.gui.title")}) {
         createResult.value = createResultData[0];
         createDone.value = true;
 
-        createForm.close();
+        this.close();
     });
     show(func (result) -> void {
         if (createDone.value) [
@@ -184,12 +184,12 @@ func buildStoreDetail(storeId: string) -> void {
         button({tr("market.gui.store.item.buy")}, on: func () -> void {
             navigateItems.value = true;
 
-            detailForm.close();
+            this.close();
         }, new ButtonOptions());
         button({tr("market.gui.store.review.button")}, on: func () -> void {
             navigateReviews.value = true;
 
-            detailForm.close();
+            this.close();
         }, reviewOption);
         closeButton();
         show(func (result) -> void {
@@ -247,7 +247,7 @@ func buildStoreItemInfo(storeId: string, itemId: string) -> void {
             buyResult.value = buyResultData[0];
             buyDone.value = true;
 
-            itemInfo.close();
+            this.close();
         });
         show(func (result) -> void {
             if (buyDone.value) [
@@ -279,7 +279,7 @@ func buildStoreReviews(storeId: string) -> void {
         ConfirmBar({tr("market.gui.store.review.button")}, func () -> void {
             navigateReviewForm.value = true;
 
-            reviews.close();
+            this.close();
         });
         show(func (result) -> void {
             if (navigateReviewForm.value) [
@@ -327,7 +327,7 @@ func buildReviewForm(storeId: string) -> void {
             reviewResult.value = reviewResultData[0];
             reviewDone.value = true;
 
-            reviewForm.close();
+            this.close();
         });
         show(func (result) -> void {
             buildStoreReviews(storeId);
@@ -371,7 +371,7 @@ func buildStoreMyItemInfo(itemId: string) -> void {
 
             offshelfDone.value = true;
 
-            itemMine.close();
+            this.close();
         });
         show(func (result) -> void {
             buildStoreMyItems();
@@ -397,13 +397,13 @@ func buildStoreDissolve() -> void {
             dissolveResult.value = dissolveResultData[0];
             dissolveDone.value = true;
 
-            dissolveForm.close();
+            this.close();
         }, new ButtonOptions());
         ConfirmBar({tr("market.no")}, func () -> void {
             dissolveResult.value = false;
             dissolveDone.value = true;
 
-            dissolveForm.close();
+            this.close();
         });
         show(func (result) -> void {
             if (dissolveDone.value) [
@@ -458,7 +458,7 @@ func buildStoreSellItem(slot: int) -> void {
             sellResult.value = sellResultData[0];
             sellDone.value = true;
 
-            sellItemForm.close();
+            this.close();
         });
         show(func (result) -> void {
             if (sellDone.value) [
@@ -512,14 +512,14 @@ func buildReviewAudit(reviewId: string) -> void {
 
             auditDone.value = true;
 
-            auditForm.close();
+            this.close();
         }, new ButtonOptions());
         ConfirmBar({tr("market.gui.store.audit.reject")}, func () -> void {
             GUIManager::request("market.store.review.audit", [ reviewId, false ]);
 
             auditDone.value = true;
 
-            auditForm.close();
+            this.close();
         });
         show(func (result) -> void {
             buildPendingReviews();

--- a/assets/common/gui/market_trade.lcui
+++ b/assets/common/gui/market_trade.lcui
@@ -39,13 +39,13 @@ tradeRequest = new CustomForm("market.trade.request", {tr("market.gui.title")}) 
         requestAccepted.value = acceptData[0];
         requestFinished.value = true;
 
-        tradeRequest.close();
+        this.close();
     }, new ButtonOptions());
     ConfirmBar({tr("market.no")}, func () -> void {
         requestRejected.value = true;
         requestFinished.value = true;
 
-        tradeRequest.close();
+        this.close();
     });
     show(func (result) -> void {
         if (!requestFinished.value) [
@@ -101,7 +101,7 @@ tradeItemForm = new CustomForm("market.trade.item", {tr("market.gui.title")}) {
 
         itemDone.value = true;
 
-        tradeItemForm.close();
+        this.close();
     });
     show(func (result) -> void {
         if (!itemDone.value) [
@@ -124,14 +124,14 @@ tradeConfirmForm = new CustomForm("market.trade.confirm", {tr("market.gui.title"
 
         confirmDone.value = true;
 
-        tradeConfirmForm.close();
+        this.close();
     }, new ButtonOptions());
     ConfirmBar({tr("market.no")}, func () -> void {
         GUIManager::callback("market.trade.cancel", []);
 
         confirmDone.value = true;
 
-        tradeConfirmForm.close();
+        this.close();
     });
     show(func (result) -> void {
         if (!confirmDone.value) [

--- a/assets/common/gui/market_wanted.lcui
+++ b/assets/common/gui/market_wanted.lcui
@@ -21,14 +21,14 @@ wanted = new PaginatedForm("market.wanted", {tr("market.gui.title")}, GUIManager
         if (!navigateWantedCreate.value) [
             navigateWantedCreate.value = true;
 
-            wanted.close();
+            this.close();
         ]
     }, createOption);
     button({tr("market.gui.wanted.mine")}, on: func () -> void {
         if (!navigateWantedMine.value) [
             navigateWantedMine.value = true;
 
-            wanted.close();
+            this.close();
         ]
     }, mineOption);
     closeButton();
@@ -78,7 +78,7 @@ func buildWantedInfo(id: string) -> void {
             fillResult.value = fillResultData[0];
             fillDone.value = true;
 
-            wantedInfo.close();
+            this.close();
         });
         show(func (result) -> void {
             if (fillDone.value) [
@@ -148,7 +148,7 @@ func buildWantedCreate(slot: int) -> void {
             createResult.value = createResultData[0];
             createDone.value = true;
 
-            wantedCreate.close();
+            this.close();
         });
         show(func (result) -> void {
             if (createDone.value) [
@@ -204,7 +204,7 @@ func buildWantedCancel(id: string) -> void {
             cancelResult.value = cancelResultData[0];
             cancelDone.value = true;
 
-            wantedCancel.close();
+            this.close();
         });
         show(func (result) -> void {
             if (cancelDone.value) [

--- a/assets/common/gui/mute.lcui
+++ b/assets/common/gui/mute.lcui
@@ -19,14 +19,14 @@ open = new CustomForm("mute.open", {tr("mute.gui.title")}) {
         if (!navigateAdd.value) [
             navigateAdd.value = true;
 
-            open.close();
+            this.close();
         ]
     }, addMuteOption);
     button({tr("mute.gui.removeMute")}, on: func () -> void {
         if (!navigateDelete.value) [
             navigateDelete.value = true;
 
-            open.close();
+            this.close();
         ]
     }, removeMuteOption);
     closeButton();
@@ -72,7 +72,7 @@ add = new PaginatedForm("mute.add", {tr("mute.gui.add.title")}, GUIManager::valu
 
                         contentValue.value = true;
 
-                        content.close();
+                        this.close();
                     });
                     show(func (result) -> void {
                         if (!contentValue.value) [
@@ -115,7 +115,7 @@ remove = new PaginatedForm("mute.remove", {tr("mute.gui.remove.title")}, GUIMana
 
                         infoRemoved.value = true;
 
-                        info.close();
+                        this.close();
                     });
                     show(func (result) -> void {
                         if (!infoRemoved.value) [

--- a/assets/common/gui/notice.lcui
+++ b/assets/common/gui/notice.lcui
@@ -35,7 +35,7 @@ if (mode.value == "content") [
             if (!navigateLines.value) [
                 navigateLines.value = true;
 
-                content.close();
+                this.close();
             ]
         }, new ButtonOptions());
         button({tr("notice.gui.edit.addline")}, on: func () -> void {
@@ -43,7 +43,7 @@ if (mode.value == "content") [
                 GUIManager::callback("notice.line.add", [ targetId.value ]);
 
                 navigateRefresh.value = true;
-                content.close();
+                this.close();
             ]
         }, new ButtonOptions());
         button({tr("notice.gui.edit.removeline")}, on: func () -> void {
@@ -51,7 +51,7 @@ if (mode.value == "content") [
                 GUIManager::callback("notice.line.remove", [ targetId.value ]);
 
                 navigateRefresh.value = true;
-                content.close();
+                this.close();
             ]
         }, new ButtonOptions());
         ConfirmBar(saveLabel(), func () -> void {
@@ -59,7 +59,7 @@ if (mode.value == "content") [
                 GUIManager::callback("notice.content.save", [ targetId.value, titleField.getData(), showField.getData() ]);
 
                 navigateRefresh.value = true;
-                content.close();
+                this.close();
             ]
         });
         show(func (result) -> void {
@@ -84,7 +84,7 @@ if (mode.value == "content") [
                                 ConfirmBar(saveLabel(), func () -> void {
                                     GUIManager::callback("notice.line.save", [ targetId.value, result.selectionIndex, lineField.getData() ]);
 
-                                    line.close();
+                                    this.close();
                                 });
                                 show(func (result) -> void {
                                     GUIManager::open("notice", "notice.content", 1, [ "content", targetId.value ]);
@@ -149,21 +149,21 @@ edit = new CustomForm("notice.edit", {tr("notice.gui.title")}) {
         if (!navigateAdd.value) [
             navigateAdd.value = true;
 
-            edit.close();
+            this.close();
         ]
     }, addOption);
     button({tr("notice.gui.remove")}, on: func () -> void {
         if (!navigateRemove.value) [
             navigateRemove.value = true;
 
-            edit.close();
+            this.close();
         ]
     }, removeOption);
     button({tr("notice.gui.edit.list")}, on: func () -> void {
         if (!navigateEdit.value) [
             navigateEdit.value = true;
 
-            edit.close();
+            this.close();
         ]
     }, editListOption);
     closeButton();
@@ -209,7 +209,7 @@ add = new CustomForm("notice.add", {tr("notice.gui.title")}) {
     ConfirmBar(saveLabel(), func () -> void {
         GUIManager::callback("notice.add.submit", [ addId.getData(), addTitle.getData(), addPriority.getData(), addShow.getData() ]);
 
-        add.close();
+        this.close();
     });
     show(func (result) -> void {
         GUIManager::open("notice", "notice.edit", 1, [ "", "" ]);
@@ -271,7 +271,7 @@ setting = new CustomForm("notice.setting", {tr("notice.gui.title")}) {
     ConfirmBar(saveLabel(), func () -> void {
         GUIManager::callback("notice.setting.save", [ closeState.getData() ]);
 
-        setting.close();
+        this.close();
     });
     show();
 };

--- a/assets/common/gui/tpa.lcui
+++ b/assets/common/gui/tpa.lcui
@@ -46,14 +46,14 @@ setting = new CustomForm("tpa.setting", {tr("tpa.gui.setting.title")}) {
         if (!navigateGeneric.value) [
             navigateGeneric.value = true;
 
-            setting.close();
+            this.close();
         ]
     }, genericOption);
     button({tr("tpa.gui.setting.blacklist")}, on: func () -> void {
         if (!navigateBlacklist.value) [
             navigateBlacklist.value = true;
 
-            setting.close();
+            this.close();
         ]
     }, blacklistOption);
     closeButton();
@@ -83,7 +83,7 @@ generic = new CustomForm("tpa.generic", {tr("tpa.gui.setting.title")}) {
             GUIManager::callback("tpa.invite.save", [ inviteState.getData() ]);
 
             inviteSaved.value = true;
-            generic.close();
+            this.close();
         ]
     });
     show(func (result) -> void {
@@ -104,7 +104,7 @@ blacklist = new PaginatedForm("tpa.blacklist", {tr("tpa.gui.setting.title")}, GU
         if (!navigateAddBlacklist.value) [
             navigateAddBlacklist.value = true;
 
-            blacklist.close();
+            this.close();
         ]
     }, addBlacklistOption);
     show(func (result) -> void {
@@ -125,7 +125,7 @@ blacklist = new PaginatedForm("tpa.blacklist", {tr("tpa.gui.setting.title")}, GU
                     ConfirmBar({tr("tpa.gui.setting.blacklist.set.remove")}, func () -> void {
                         GUIManager::callback("tpa.blacklist.remove", [ result.selection ]);
 
-                        info.close();
+                        this.close();
                     });
                     show(func (result) -> void {
                         GUIManager::open("tpa", "tpa.blacklist", 3, [ "", "" ]);
@@ -186,7 +186,7 @@ func buildContent(targetUuid: string) -> void {
             submitResult = GUIManager::request("tpa.content.submit", [ targetUuid, typeValue.getData() ]);
 
             submitDone.value = submitResult[0];
-            content.close();
+            this.close();
         });
         show(func (result) -> void {
             if (!submitDone.value) [

--- a/assets/common/gui/wallet.lcui
+++ b/assets/common/gui/wallet.lcui
@@ -51,21 +51,21 @@ open = new CustomForm("wallet.open", {tr("wallet.gui.title")}) {
         if (!navigateOnline.value) [
             navigateOnline.value = true;
 
-            open.close();
+            this.close();
         ]
     }, onlineOption);
     button({tr("wallet.gui.offlineTransfer")}, on: func () -> void {
         if (!navigateOffline.value) [
             navigateOffline.value = true;
 
-            open.close();
+            this.close();
         ]
     }, offlineOption);
     button({tr("wallet.gui.redenvelope")}, on: func () -> void {
         if (!navigateRedenvelope.value) [
             navigateRedenvelope.value = true;
 
-            open.close();
+            this.close();
         ]
     }, redenvelopeOption);
     button({tr("wallet.gui.wealth")}, on: func () -> void {
@@ -73,28 +73,28 @@ open = new CustomForm("wallet.open", {tr("wallet.gui.title")}) {
             GUIManager::callback("wallet.wealth", []);
 
             navigateWealth.value = true;
-            open.close();
+            this.close();
         ]
     }, wealthOption);
     button({tr("wallet.gui.history")}, on: func () -> void {
         if (!navigateHistory.value) [
             navigateHistory.value = true;
 
-            open.close();
+            this.close();
         ]
     }, historyOption);
     button({tr("wallet.gui.bank")}, on: func () -> void {
         if (!navigateBank.value) [
             navigateBank.value = true;
 
-            open.close();
+            this.close();
         ]
     }, bankOption);
     button({tr("wallet.gui.rank")}, on: func () -> void {
         if (!navigateRank.value) [
             navigateRank.value = true;
 
-            open.close();
+            this.close();
         ]
     }, rankOption);
     closeButton();
@@ -174,7 +174,7 @@ func buildTransferContent(transferType: string, index: int) -> void {
                 GUIManager::switchTo("wallet.confirm", 2);
             :
                 submitDone.value = submitResult[0];
-                content.close();
+                this.close();
             ]
         });
         show(func (result) -> void {
@@ -250,7 +250,7 @@ redenvelope = new CustomForm("wallet.redenvelope", {tr("wallet.gui.title")}) {
         submitResult = GUIManager::request("wallet.redenvelope.submit", [ redeemScore.getData(), redeemCount.getData(), redeemKey.getData(), redeemTargets.getData() ]);
 
         redeemDone.value = submitResult[0];
-        redenvelope.close();
+        this.close();
     });
     show(func (result) -> void {
         if (!redeemDone.value) [
@@ -295,13 +295,13 @@ bank = new CustomForm("wallet.bank", {tr("wallet.gui.title")}) {
         bankResult = GUIManager::request("wallet.bank.deposit", [ bankDepositInput.getData() ]);
 
         bankDone.value = bankResult[0];
-        bank.close();
+        this.close();
     }, new ButtonOptions());
     ConfirmBar({tr("wallet.gui.bank.withdraw.button")}, func () -> void {
         bankResult = GUIManager::request("wallet.bank.withdraw", []);
 
         bankDone.value = bankResult[0];
-        bank.close();
+        this.close();
     });
     show(func (result) -> void {
         if (!bankDone.value) [

--- a/src/LOICollectionA/LOICollectionA.cpp
+++ b/src/LOICollectionA/LOICollectionA.cpp
@@ -21,6 +21,7 @@
 #include "LOICollectionA/include/ModuleBase.h"
 #include "LOICollectionA/include/ModManager.h"
 #include "LOICollectionA/include/CallbackUtils.h"
+#include "LOICollectionA/include/form/GUIManager.h"
 
 #include "LOICollectionA/base/Wrapper.h"
 #include "LOICollectionA/base/ServiceProvider.h"
@@ -180,6 +181,8 @@ namespace LOICollection {
 
     bool A::disable() {
         ll::io::Logger& logger = this->mSelf.getLogger();
+
+        form::GUIManager::getInstance().releaseAllUI();
 
         std::vector<std::string> mMods = modules::ModManager::getInstance().mods();
         std::for_each(mMods.begin(), mMods.end(), [&logger](const std::string& mod) -> void {

--- a/src/LOICollectionA/frontend/AST.h
+++ b/src/LOICollectionA/frontend/AST.h
@@ -827,6 +827,8 @@ namespace LOICollection::frontend {
 
     struct NativeHandle {
         virtual ~NativeHandle() = default;
+
+        virtual void release() {}
     };
 
     struct Object {
@@ -845,6 +847,8 @@ namespace LOICollection::frontend {
         struct BytecodeChunk;
     }
 
+    using GlobalsTable = std::unordered_map<std::string, ValueNode::ValueType>;
+
     struct FunctionRef {
         std::shared_ptr<const ir::BytecodeChunk> owner;
 
@@ -852,9 +856,9 @@ namespace LOICollection::frontend {
         int argCount = 0;
 
         bool hasThis = false;
-        ObjectRef thisObj;
+        std::weak_ptr<Object> thisObj;
 
         std::vector<ValueNode::ValueType> captures;
-        std::unordered_map<std::string, ValueNode::ValueType> globals;
+        std::weak_ptr<GlobalsTable> globals;
     };
 }

--- a/src/LOICollectionA/frontend/SemanticAnalyzer.cpp
+++ b/src/LOICollectionA/frontend/SemanticAnalyzer.cpp
@@ -7,6 +7,8 @@
 #include <unordered_set>
 #include <utility>
 
+#include "LOICollectionA/base/ScopeGuard.h"
+
 #include "LOICollectionA/frontend/Callback.h"
 
 #include "LOICollectionA/frontend/SemanticAnalyzer.h"
@@ -83,6 +85,9 @@ namespace LOICollection::frontend {
         this->constructorAssignedMembers.clear();
         this->blockScopes.clear();
         this->formReceivers.clear();
+        this->receiverBindings.clear();
+        this->receiverCaptures.clear();
+        this->closureDepth = 0;
 
         this->collectTypeAliases(root);
 
@@ -512,6 +517,9 @@ namespace LOICollection::frontend {
                 return;
             case ASTNode::Type::While: {
                 auto& whileNode = static_cast<WhileNode&>(node);
+                ++scope.loopDepth;
+                auto loops = make_scope_guard([&scope] { --scope.loopDepth; });
+
                 if (whileNode.condition)
                     checkExpr(*whileNode.condition, scope);
                 if (whileNode.body)
@@ -520,6 +528,9 @@ namespace LOICollection::frontend {
             }
             case ASTNode::Type::For: {
                 auto& forNode = static_cast<ForNode&>(node);
+                ++scope.loopDepth;
+                auto loops = make_scope_guard([&scope] { --scope.loopDepth; });
+
                 if (forNode.init)
                     checkExpr(*forNode.init, scope);
                 if (forNode.condition)
@@ -532,6 +543,10 @@ namespace LOICollection::frontend {
             }
             case ASTNode::Type::ForIn: {
                 auto& forIn = static_cast<ForInNode&>(node);
+
+                ++scope.loopDepth;
+                auto loops = make_scope_guard([&scope] { --scope.loopDepth; });
+
                 TypeInfo iterableType = checkExpr(*forIn.iterable, scope);
 
                 bool isRange = forIn.iterable->getType() == ASTNode::Type::Range;
@@ -558,7 +573,14 @@ namespace LOICollection::frontend {
                 return;
             }
             case ASTNode::Type::Break:
+                if (scope.loopDepth == 0)
+                    this->diagnostics.addError(static_cast<BreakNode&>(node).loc,
+                        "'break' can only be used inside a loop");
+                return;
             case ASTNode::Type::Continue:
+                if (scope.loopDepth == 0)
+                    this->diagnostics.addError(static_cast<ContinueNode&>(node).loc,
+                        "'continue' can only be used inside a loop");
                 return;
             case ASTNode::Type::Block:
                 for (auto& part : static_cast<BlockNode&>(node).parts)
@@ -611,7 +633,7 @@ namespace LOICollection::frontend {
                 TypeInfo left = checkExpr(*coalesce.left, scope);
                 TypeInfo right = checkExpr(*coalesce.right, scope);
 
-                // None / empty optional is meaningful for '??': keep the raw value.
+                
                 coalesce.left->preserveOptional = true;
 
                 while (left.kind == TypeKind::Optional)
@@ -644,6 +666,16 @@ namespace LOICollection::frontend {
             case ASTNode::Type::Variable: {
                 auto& var = static_cast<VariableNode&>(node);
                 TypeInfo type = lookupName(var.name, scope);
+
+                if (this->closureDepth > 0) {
+                    for (const auto& binding : this->receiverBindings) {
+                        if (binding.name != var.name)
+                            continue;
+
+                        this->receiverCaptures.push_back({ var.name, var.loc });
+                        break;
+                    }
+                }
 
                 if (scope.hasClass()) {
                     bool isParam = false;
@@ -687,17 +719,20 @@ namespace LOICollection::frontend {
 
             case ASTNode::Type::This: {
                 auto& self = static_cast<ThisNode&>(node);
-                if (!scope.hasMethod() || !scope.hasClass()) {
-                    diagnostics.addError(self.loc, "'this' is only available inside class methods");
-                    return {};
+                if (scope.hasMethod() && scope.hasClass()) {
+                    if (scope.methodRef().isStatic) {
+                        diagnostics.addError(self.loc, "'this' is not available inside static methods");
+                        return {};
+                    }
+
+                    return { TypeKind::Object, scope.classRef().name };
                 }
 
-                if (scope.methodRef().isStatic) {
-                    diagnostics.addError(self.loc, "'this' is not available inside static methods");
-                    return {};
-                }
+                if (this->closureDepth > 0 && !this->receiverBindings.empty())
+                    return { TypeKind::Object, this->receiverBindings.back().className };
 
-                return { TypeKind::Object, scope.classRef().name };
+                diagnostics.addError(self.loc, "'this' is only available inside class methods");
+                return {};
             }
 
             case ASTNode::Type::Super: {
@@ -970,8 +1005,8 @@ namespace LOICollection::frontend {
                 }
 
                 if (rhs.kind == TypeKind::None) {
-                    // Dynamic variables may hold 'None' (e.g. before a '??' fallback);
-                    // the inferred type stays dynamic so later assignments remain valid.
+                    
+                    
                     globalTypes[var.name] = TypeInfo{};
                     return rhs;
                 }
@@ -1157,7 +1192,7 @@ namespace LOICollection::frontend {
 
         bool safeMaybeNone = false;
         if (node.isSafe) {
-            // None / empty optional short-circuits a safe chain: keep the raw target.
+            
             node.target->preserveOptional = true;
             safeMaybeNone = targetType.kind == TypeKind::Optional ||
                             targetType.kind == TypeKind::Unknown;
@@ -1274,17 +1309,49 @@ namespace LOICollection::frontend {
         return {};
     }
 
+    std::string SemanticAnalyzer::receiverVariable(MethodCallNode& node) const {
+        if (node.isStaticCall || node.target->getType() != ASTNode::Type::Variable)
+            return {};
+
+        const std::string& name = static_cast<VariableNode&>(*node.target).name;
+        if (this->classByName.contains(name) || isNativeClass(name))
+            return {};
+
+        return name;
+    }
+
+    void SemanticAnalyzer::reportReceiverCaptures(const std::string& name) {
+        std::vector<ReceiverCapture> remaining;
+        for (auto& capture : this->receiverCaptures) {
+            if (capture.name != name) {
+                remaining.push_back(capture);
+                continue;
+            }
+
+            this->diagnostics.addError(capture.loc,
+                "Callback captures its receiver '" + name +
+                "'; the closure would retain the object and leak it, use 'this' instead");
+        }
+
+        this->receiverCaptures = std::move(remaining);
+    }
+
     TypeInfo SemanticAnalyzer::checkMethodCall(MethodCallNode& node, MethodScope& scope) {
         size_t argCount = node.args.size();
 
-        std::vector<TypeInfo> argTypes;
-        argTypes.reserve(argCount);
-        for (auto& arg : node.args)
-            argTypes.push_back(checkExpr(*arg, scope));
+        auto checkArgs = [&] {
+            std::vector<TypeInfo> types;
+            types.reserve(argCount);
+            for (auto& arg : node.args)
+                types.push_back(checkExpr(*arg, scope));
+            return types;
+        };
 
         if (node.target->getType() == ASTNode::Type::Variable) {
             auto& var = static_cast<VariableNode&>(*node.target);
             if (auto clsOpt = this->findClass(var.name)) {
+                std::vector<TypeInfo> argTypes = checkArgs();
+
                 auto staticMethod = this->findStaticMethod(
                     clsOpt->get(), node.methodName, argTypes, scope
                 );
@@ -1314,6 +1381,8 @@ namespace LOICollection::frontend {
             }
 
             if (isNativeClass(var.name)) {
+                std::vector<TypeInfo> argTypes = checkArgs();
+
                 std::vector<CallbackTypeArgs> signatures =
                     ClassCall::getInstance().getStaticMethodSignatures(var.name, node.methodName);
 
@@ -1338,6 +1407,21 @@ namespace LOICollection::frontend {
         while (targetType.kind == TypeKind::Optional)
             targetType = *targetType.optionalInner;
 
+        std::string receiverVar;
+        if (targetType.kind == TypeKind::Object)
+            receiverVar = this->receiverVariable(node);
+
+        std::vector<TypeInfo> argTypes;
+        if (!receiverVar.empty()) {
+            this->receiverBindings.push_back({ receiverVar, targetType.className });
+            auto binding = make_scope_guard([this] { this->receiverBindings.pop_back(); });
+
+            argTypes = checkArgs();
+            this->reportReceiverCaptures(receiverVar);
+        } else {
+            argTypes = checkArgs();
+        }
+
         if (targetType.kind == TypeKind::Array || targetType.kind == TypeKind::String) {
             const std::string& className = targetType.kind == TypeKind::Array ? "Array" : "String";
             std::vector<CallbackTypeArgs> signatures =
@@ -1358,9 +1442,9 @@ namespace LOICollection::frontend {
         }
 
         if (targetType.kind == TypeKind::Unknown) {
-            /* Dynamically typed target (e.g. a member read of an object or native
-             * instance): defer the value-method dispatch to the VM, which selects
-             * the value class by the runtime type of the receiver. */
+            
+
+
             for (const char* className : { "Array", "String" }) {
                 std::vector<CallbackTypeArgs> signatures =
                     ClassCall::getInstance().getValueMethodSignatures(className, node.methodName);
@@ -1882,6 +1966,9 @@ namespace LOICollection::frontend {
         if (scope.hasClass())
             lambdaScope.cls = scope.cls;
         lambdaScope.method = std::ref(decl);
+
+        ++this->closureDepth;
+        auto closure = make_scope_guard([this] { --this->closureDepth; });
 
         if (decl.body)
             checkStatement(*decl.body, lambdaScope);

--- a/src/LOICollectionA/frontend/SemanticAnalyzer.h
+++ b/src/LOICollectionA/frontend/SemanticAnalyzer.h
@@ -24,6 +24,8 @@ namespace LOICollection::frontend {
             std::optional<std::reference_wrapper<ClassNode>> cls;
             std::optional<std::reference_wrapper<MethodDecl>> method;
 
+            int loopDepth = 0;
+
             [[nodiscard]] bool hasClass() const { return cls.has_value(); }
             [[nodiscard]] bool hasMethod() const { return method.has_value(); }
             [[nodiscard]] ClassNode& classRef() const { return cls->get(); }
@@ -45,10 +47,23 @@ namespace LOICollection::frontend {
             std::reference_wrapper<ClassNode> owner;
         };
 
+        struct ReceiverBinding {
+            std::string name;
+            std::string className;
+        };
+
+        struct ReceiverCapture {
+            std::string name;
+            SourceLocation loc;
+        };
+
         DiagnosticEngine& diagnostics;
 
         std::vector<std::unordered_map<std::string, TypeInfo>> blockScopes;
         std::vector<std::string> formReceivers;
+        std::vector<ReceiverBinding> receiverBindings;
+        std::vector<ReceiverCapture> receiverCaptures;
+        int closureDepth = 0;
 
         std::vector<std::reference_wrapper<ClassNode>> classes;
         std::vector<std::reference_wrapper<ClassNode>> orderedClasses;
@@ -75,6 +90,8 @@ namespace LOICollection::frontend {
         [[nodiscard]] bool isNumeric(const TypeInfo& type) const;
         [[nodiscard]] bool isNameDefined(const std::string& name, MethodScope& scope) const;
         [[nodiscard]] bool isAssignableTo(const TypeInfo& target, const TypeInfo& from) const;
+        [[nodiscard]] std::string receiverVariable(MethodCallNode& node) const;
+        void reportReceiverCaptures(const std::string& name);
 
         void registerClass(ClassNode& node);
         void collectTypeAliases(ProgramNode& root);

--- a/src/LOICollectionA/frontend/builtin/ui/form/CustomFormClass.h
+++ b/src/LOICollectionA/frontend/builtin/ui/form/CustomFormClass.h
@@ -13,6 +13,12 @@ namespace CustomFormClass {
 
         LOICollection::frontend::FunctionRefPtr show;
         std::string scriptId;
+
+        void release() override {
+            this->show.reset();
+        }
+
+        ~CustomFormHandle() override { this->release(); }
     };
 
     void registerClasses(const std::string& name);

--- a/src/LOICollectionA/frontend/builtin/ui/form/MessageBoxClass.h
+++ b/src/LOICollectionA/frontend/builtin/ui/form/MessageBoxClass.h
@@ -13,6 +13,12 @@ namespace MessageBoxClass {
 
         LOICollection::frontend::FunctionRefPtr show;
         std::string scriptId;
+
+        void release() override {
+            this->show.reset();
+        }
+
+        ~MessageBoxHandle() override { this->release(); }
     };
 
     void registerClasses(const std::string& name);

--- a/src/LOICollectionA/frontend/builtin/ui/form/PaginatedFormClass.h
+++ b/src/LOICollectionA/frontend/builtin/ui/form/PaginatedFormClass.h
@@ -46,6 +46,12 @@ namespace PaginatedFormClass {
         LOICollection::frontend::FunctionRefPtr show;
         std::unique_ptr<ll::ui::CustomForm> base;
         std::string scriptId;
+
+        void release() override {
+            this->show.reset();
+        }
+
+        ~PaginatedFormHandle() override { this->release(); }
     };
 
     void refreshPage(const std::shared_ptr<PaginatedFormHandle>& form);

--- a/src/LOICollectionA/frontend/builtin/ui/form/ScriptFormClass.h
+++ b/src/LOICollectionA/frontend/builtin/ui/form/ScriptFormClass.h
@@ -25,5 +25,14 @@ namespace ScriptFormClass {
 
         std::string scriptId;
         bool pendingSubflow = false;
+
+        void release() override {
+            this->show.reset();
+            this->makeResult = nullptr;
+            this->onClosed = nullptr;
+            this->onBoxResult = nullptr;
+        }
+
+        ~ScriptFormHandle() override { this->release(); }
     };
 }

--- a/src/LOICollectionA/frontend/ir/Compiler.cpp
+++ b/src/LOICollectionA/frontend/ir/Compiler.cpp
@@ -1,6 +1,7 @@
 #include <algorithm>
 #include <iterator>
 #include <memory>
+#include <utility>
 #include <vector>
 #include <functional>
 #include <unordered_map>
@@ -25,6 +26,14 @@ namespace LOICollection::frontend::ir {
     }
 
     Compiler::Compiler(DiagnosticEngine& diag) : current(std::ref(chunk)), diagnostics(diag) {}
+
+    auto Compiler::suspendLoops() {
+        auto saved = std::exchange(this->loopStack, {});
+
+        return make_scope_guard([this, saved = std::move(saved)]() mutable {
+            this->loopStack = std::move(saved);
+        });
+    }
 
     BytecodeChunk Compiler::compile(ASTNode& root) {
         this->pushScope(false, 0);
@@ -844,6 +853,7 @@ namespace LOICollection::frontend::ir {
 
             std::reference_wrapper<BytecodeChunk> saved = this->current;
             this->current = std::ref(bodyChunk);
+            auto loops = this->suspendLoops();
 
             this->pushScope(true, 0);
             for (const auto& param : method.params)
@@ -1048,7 +1058,7 @@ namespace LOICollection::frontend::ir {
                     this->current.get().emit(OpCode::HAS_VALUE, 0, node.loc);
                     break;
                 case MemberAccessNode::MemberKind::Value:
-                    // The target is known to be non-None here: unwrapping is an identity.
+                    
                     this->current.get().emit(OpCode::UNWRAP, 0, node.loc);
                     break;
                 default: {
@@ -1128,8 +1138,15 @@ namespace LOICollection::frontend::ir {
     }
 
     void Compiler::visit(MethodCallNode& node) {
-        for (auto& arg : node.args)
-            this->compileValue(*arg, node.loc);
+        const bool bindsReceiver = !this->scopes.back().hasThis;
+
+        std::vector<int> callbackArgs;
+        for (size_t i = 0; i < node.args.size(); ++i) {
+            this->compileValue(*node.args[i], node.loc);
+
+            if (bindsReceiver && node.args[i]->getType() == ASTNode::Type::Lambda)
+                callbackArgs.push_back(static_cast<int>(i));
+        }
 
         if (node.isStaticCall) {
             if (ClassCall::getInstance().isRegistered(node.staticClassName)) {
@@ -1151,6 +1168,10 @@ namespace LOICollection::frontend::ir {
         }
 
         this->compileValue(*node.target, node.loc);
+
+        for (int arg : callbackArgs)
+            this->current.get().emit(
+                OpCode::BIND_THIS, static_cast<int>(node.args.size()) - arg, node.loc);
 
         auto it = classMethodIndices.find(node.className);
         if (it != classMethodIndices.end() && node.methodOrdinal >= 0 &&
@@ -1235,6 +1256,7 @@ namespace LOICollection::frontend::ir {
 
         std::reference_wrapper<BytecodeChunk> saved = this->current;
         this->current = std::ref(bodyChunk);
+        auto loops = this->suspendLoops();
 
         this->pushScope(false, 0);
         for (const auto& param : node.decl.params)
@@ -1306,6 +1328,7 @@ namespace LOICollection::frontend::ir {
 
         std::reference_wrapper<BytecodeChunk> saved = this->current;
         this->current = std::ref(bodyChunk);
+        auto loops = this->suspendLoops();
 
         this->pushScope(false, this->scopes.back().next, true);
         for (const auto& param : node.decl.params)

--- a/src/LOICollectionA/frontend/ir/Compiler.h
+++ b/src/LOICollectionA/frontend/ir/Compiler.h
@@ -8,6 +8,7 @@
 #include <unordered_set>
 
 #include "LOICollectionA/base/Macro.h"
+#include "LOICollectionA/base/ScopeGuard.h"
 
 #include "LOICollectionA/frontend/AST.h"
 #include "LOICollectionA/frontend/DiagnosticEngine.h"
@@ -123,6 +124,8 @@ namespace LOICollection::frontend::ir {
         int addSuperCall(int constructorIndex, int argCount);
 
         [[nodiscard]] std::string methodSignature(const MethodDecl& method) const;
+
+        [[nodiscard]] auto suspendLoops();
 
         void pushScope(bool hasThis, int base, bool inherits = false);
         int closeScope();

--- a/src/LOICollectionA/frontend/ir/OpCode.h
+++ b/src/LOICollectionA/frontend/ir/OpCode.h
@@ -44,6 +44,7 @@ namespace LOICollection::frontend::ir {
         DUP_STORE,
         DUP_STORE_SLOT,
         DUP_IS_NONE,
-        LOAD_LEN
+        LOAD_LEN,
+        BIND_THIS
     };
 }

--- a/src/LOICollectionA/frontend/ir/VM.cpp
+++ b/src/LOICollectionA/frontend/ir/VM.cpp
@@ -146,8 +146,8 @@ namespace LOICollection::frontend::ir {
             }
         }
 
-        /* Fall back to the right operand's operator so "literal + observable"
-         * works like "observable + literal" instead of silently stringifying. */
+        
+
         if (auto rightObj = std::get_if<ObjectRef>(&right)) {
             if (ClassCall::getInstance().hasOperator((*rightObj)->className, op)) {
                 auto result = ClassCall::getInstance().callOperator(
@@ -307,8 +307,8 @@ namespace LOICollection::frontend::ir {
             }
         }
 
-        /* Mirror the arithmetic fallback: "literal == observable" dispatches on
-         * the right operand's operator. */
+        
+
         if (auto rightObj = std::get_if<ObjectRef>(&right)) {
             if (ClassCall::getInstance().hasOperator((*rightObj)->className, op)) {
                 auto result = ClassCall::getInstance().callOperator(
@@ -433,7 +433,7 @@ namespace LOICollection::frontend::ir {
             return;
         }
 
-        this->variables[name] = val;
+        (*this->globals)[name] = val;
     }
 
     bool VM::pushFrame(Frame&& frame) {
@@ -468,12 +468,12 @@ namespace LOICollection::frontend::ir {
 
         this->stack.clear();
         this->frames.clear();
-        this->variables.clear();
+        this->globals->clear();
         this->mReport = sandbox::SandboxReport{};
 
         for (const auto& cls : chunk->classes) {
             for (size_t i = 0; i < cls.staticFieldNames.size(); ++i) {
-                this->variables[cls.name + "::" + cls.staticFieldNames[i]] =
+                (*this->globals)[cls.name + "::" + cls.staticFieldNames[i]] =
                     cls.staticHasDefault[i]
                         ? VM::cloneValue(cls.staticDefaults[i])
                         : ValueNode::ValueType{};
@@ -707,8 +707,8 @@ namespace LOICollection::frontend::ir {
                         break;
                     }
 
-                    auto globalIt = this->variables.find(name);
-                    if (globalIt == this->variables.end()) {
+                    auto globalIt = this->globals->find(name);
+                    if (globalIt == this->globals->end()) {
                         this->diagnostics.addError(this->currentLoc, "Undefined variable: " + name);
                         break;
                     }
@@ -808,6 +808,32 @@ namespace LOICollection::frontend::ir {
                     this->diagnostics.addError(this->currentLoc, "Cannot take length of a non-iterable value");
                     break;
                 }
+                case OpCode::BIND_THIS: {
+                    if (instr.operand <= 0 || this->stack.empty())
+                        break;
+
+                    const size_t depth = static_cast<size_t>(instr.operand);
+                    if (depth >= this->stack.size())
+                        break;
+
+                    const auto* self = std::get_if<ObjectRef>(&this->stack.back());
+                    if (!self || !*self)
+                        break;
+
+                    auto& slot = this->stack[this->stack.size() - 1 - depth];
+                    auto* func = std::get_if<FunctionRefPtr>(&slot);
+                    if (!func || !*func)
+                        break;
+
+                    (*func)->hasThis = true;
+                    (*func)->thisObj = *self;
+
+                    for (auto& captured : (*func)->captures) {
+                        if (const auto* held = std::get_if<ObjectRef>(&captured); held && *held == *self)
+                            captured = std::monostate{};
+                    }
+                    break;
+                }
                 case OpCode::STORE_FIELD: {
                     const auto& name = std::get<std::string>(cur.constants[instr.operand]);
                     auto objValue = this->pop();
@@ -886,6 +912,12 @@ namespace LOICollection::frontend::ir {
                         break;
                     }
 
+                    if (auto* nested = std::get_if<ArrayRef>(&value); nested && nested->get() == arr.get()) {
+                        this->diagnostics.addError(this->currentLoc,
+                            "Circular reference: an array cannot contain itself");
+                        break;
+                    }
+
                     if (index == static_cast<int>(arr->elements.size())) {
                         if (static_cast<std::size_t>(index + 1) > this->mBudget->maxArrayElements) {
                             fail(sandbox::SandboxBudget::Violation::ArrayElementLimit, "Array size budget exhausted");
@@ -922,7 +954,7 @@ namespace LOICollection::frontend::ir {
                         frame.locals.begin(),
                         frame.locals.begin() + std::min(static_cast<size_t>(meta.captureCount), frame.locals.size())
                     );
-                    func->globals = this->variables;
+                    func->globals = this->globals;
 
                     this->push(func);
                     break;
@@ -1282,8 +1314,15 @@ namespace LOICollection::frontend::ir {
 
                     Frame callee(*func->owner->methodBodies[func->bodyIndex]);
                     callee.hasThis = func->hasThis;
-                    if (func->hasThis)
-                        callee.thisObj = func->thisObj;
+                    if (func->hasThis) {
+                        auto self = func->thisObj.lock();
+                        if (!self) {
+                            this->diagnostics.addError(this->currentLoc, "Method receiver has been released");
+                            break;
+                        }
+
+                        callee.thisObj = self;
+                    }
 
                     const size_t paramBase = func->captures.size();
                     if (paramBase + static_cast<size_t>(func->argCount) > callee.locals.size()) {
@@ -1574,16 +1613,25 @@ namespace LOICollection::frontend::ir {
             ~CallDepthGuard() { --depth; }
         } depthGuard{ nativeCallDepth };
 
-        VM vm(diagnostics);
+        auto snapshot = func->globals.lock();
+        VM vm(diagnostics, snapshot
+            ? std::make_shared<GlobalsTable>(*snapshot)
+            : std::make_shared<GlobalsTable>());
+
         vm.stack.clear();
         vm.frames.clear();
-        vm.variables.clear();
-        vm.variables = func->globals;
 
         Frame callee(*func->owner->methodBodies[func->bodyIndex]);
         callee.hasThis = func->hasThis;
-        if (func->hasThis)
-            callee.thisObj = func->thisObj;
+        if (func->hasThis) {
+            auto self = func->thisObj.lock();
+            if (!self) {
+                diagnostics.addError({}, "Method receiver has been released");
+                return std::monostate{};
+            }
+
+            callee.thisObj = self;
+        }
 
         const size_t paramBase = func->captures.size();
         if (paramBase + static_cast<size_t>(func->argCount) > callee.locals.size()) {

--- a/src/LOICollectionA/frontend/ir/VM.h
+++ b/src/LOICollectionA/frontend/ir/VM.h
@@ -18,7 +18,11 @@
 namespace LOICollection::frontend::ir {
     class VM {
     public:
-        LOICOLLECTION_A_NDAPI VM(DiagnosticEngine& diag) : diagnostics(diag) {}
+        LOICOLLECTION_A_NDAPI VM(DiagnosticEngine& diag) : VM(diag, std::make_shared<GlobalsTable>()) {}
+
+        LOICOLLECTION_A_NDAPI VM(DiagnosticEngine& diag, std::shared_ptr<GlobalsTable> globals)
+            : diagnostics(diag),
+              globals(std::move(globals)) {}
 
         LOICOLLECTION_A_NDAPI ValueNode::ValueType run(
             const std::shared_ptr<const BytecodeChunk>& chunk,
@@ -68,7 +72,8 @@ namespace LOICollection::frontend::ir {
 
         std::vector<Frame> frames;
         std::vector<ValueNode::ValueType> stack;
-        std::unordered_map<std::string, ValueNode::ValueType> variables;
+
+        std::shared_ptr<GlobalsTable> globals;
 
         std::unordered_map<int, FunctionCallCacheSlot> mFunctionCallSlots;
         std::unordered_map<int, NativeMethodCacheSlot> mNativeMethodSlots;

--- a/src/LOICollectionA/frontend/stdlib/ArrayClass.cpp
+++ b/src/LOICollectionA/frontend/stdlib/ArrayClass.cpp
@@ -51,10 +51,10 @@ namespace ArrayClass {
             DiagnosticEngine diagnostics;
             bool failed = false;
 
-            /* Script comparators are not trusted to satisfy the strict weak
-             * ordering required by std::sort (violating it is UB). A bottom-up
-             * merge sort keeps every access in bounds even for inconsistent
-             * comparators; on failure the array is left in a valid state. */
+            
+
+
+
             auto less = [&](const TypedValue& left, const TypedValue& right) -> bool {
                 if (failed)
                     return false;
@@ -110,6 +110,10 @@ namespace ArrayClass {
 
     ll::Expected<TypedValue> push(const TypedValue& self, const CallbackTypeValues& args) {
         auto arr = std::get<ArrayRef>(self);
+
+        if (auto* nested = std::get_if<ArrayRef>(&args[0]); nested && nested->get() == arr.get())
+            return ll::makeStringError("Circular reference: an array cannot contain itself");
+
         arr->elements.push_back(args[0]);
 
         return static_cast<int>(arr->elements.size());

--- a/src/LOICollectionA/frontend/stdlib/ObservableBooleanClass.cpp
+++ b/src/LOICollectionA/frontend/stdlib/ObservableBooleanClass.cpp
@@ -62,7 +62,9 @@ namespace ObservableBooleanClass {
         if (func->argCount != 1)
             return ll::makeStringError("Subscribe function only needs one bool parameter");
 
-        return static_cast<ObservableBooleanHandle*>(self->native.get())->base->subscribe([func, placeholders](const bool& value) -> void {
+        auto* handle = static_cast<ObservableBooleanHandle*>(self->native.get());
+
+        auto id = handle->base->subscribe([func, placeholders](const bool& value) -> void {
             DiagnosticEngine diagnostics;
 
             [[maybe_unused]] auto result = ir::VM::callFunctionRef(func, { value }, placeholders, diagnostics);
@@ -72,10 +74,18 @@ namespace ObservableBooleanClass {
                     ->error("ObservableBoolean::subscribe callback: {}", diagnostics.getErrorMessage());
             }
         });
+
+        handle->subscriptions.push_back(id);
+        return id;
     }
 
     bool unsubscribe(const ObjectRef& self, const CallbackTypeValues& args) {
-        return static_cast<ObservableBooleanHandle*>(self->native.get())->base->unsubscribe(std::get<int>(args[0]));
+        auto* handle = static_cast<ObservableBooleanHandle*>(self->native.get());
+        auto id = static_cast<ObservableBooleanHandle::SubscriptionId>(std::get<int>(args[0]));
+
+        std::erase(handle->subscriptions, id);
+
+        return handle->base->unsubscribe(id);
     }
 
     void registerClasses(const std::string&) {
@@ -89,7 +99,7 @@ namespace ObservableBooleanClass {
         classes.registerMethod("ObservableBoolean", "subscribe", subscribe, { ParamType::FUNCTION });
         classes.registerMethod("ObservableBoolean", "unsubscribe", unsubscribe, { ParamType::INT });
 
-        // "obs == x" mirrors "getData() == x".
+        
         for (const std::string& op : { "==", "!=" })
             classes.registerOperator("ObservableBoolean", op, [op](const TypedValue& left, const TypedValue& right) -> ll::Expected<TypedValue> {
                 auto l = boolOperand(left);

--- a/src/LOICollectionA/frontend/stdlib/ObservableBooleanClass.h
+++ b/src/LOICollectionA/frontend/stdlib/ObservableBooleanClass.h
@@ -2,6 +2,7 @@
 
 #include <memory>
 #include <string>
+#include <vector>
 
 #include <ll/api/ui/base/Observable.h>
 
@@ -10,6 +11,18 @@
 namespace ObservableBooleanClass {
     struct ObservableBooleanHandle : LOICollection::frontend::NativeHandle {
         std::unique_ptr<ll::ui::ObservableBoolean> base;
+        using SubscriptionId = ll::ui::ObservableBoolean::SubscriptionId;
+        std::vector<SubscriptionId> subscriptions;
+
+        void release() override {
+            if (this->base)
+                for (SubscriptionId id : this->subscriptions)
+                    this->base->unsubscribe(id);
+
+            this->subscriptions.clear();
+        }
+
+        ~ObservableBooleanHandle() override { this->release(); }
     };
 
     void registerClasses(const std::string& name);

--- a/src/LOICollectionA/frontend/stdlib/ObservableNumberClass.cpp
+++ b/src/LOICollectionA/frontend/stdlib/ObservableNumberClass.cpp
@@ -109,7 +109,9 @@ namespace ObservableNumberClass {
         if (func->argCount != 1)
             return ll::makeStringError("Subscribe function only needs one float parameter");
 
-        return static_cast<ObservableNumberHandle*>(self->native.get())->base->subscribe([func, placeholders](const double& value) -> void {
+        auto* handle = static_cast<ObservableNumberHandle*>(self->native.get());
+
+        auto id = handle->base->subscribe([func, placeholders](const double& value) -> void {
             DiagnosticEngine diagnostics;
 
             [[maybe_unused]] auto result = ir::VM::callFunctionRef(func, { static_cast<float>(value) }, placeholders, diagnostics);
@@ -119,10 +121,18 @@ namespace ObservableNumberClass {
                     ->error("ObservableNumber::subscribe callback: {}", diagnostics.getErrorMessage());
             }
         });
+
+        handle->subscriptions.push_back(id);
+        return id;
     }
 
     bool unsubscribe(const ObjectRef& self, const CallbackTypeValues& args) {
-        return static_cast<ObservableNumberHandle*>(self->native.get())->base->unsubscribe(std::get<int>(args[0]));
+        auto* handle = static_cast<ObservableNumberHandle*>(self->native.get());
+        auto id = static_cast<ObservableNumberHandle::SubscriptionId>(std::get<int>(args[0]));
+
+        std::erase(handle->subscriptions, id);
+
+        return handle->base->unsubscribe(id);
     }
 
     void registerClasses(const std::string&) {

--- a/src/LOICollectionA/frontend/stdlib/ObservableNumberClass.h
+++ b/src/LOICollectionA/frontend/stdlib/ObservableNumberClass.h
@@ -2,6 +2,7 @@
 
 #include <memory>
 #include <string>
+#include <vector>
 
 #include <ll/api/ui/base/Observable.h>
 
@@ -10,6 +11,18 @@
 namespace ObservableNumberClass {
     struct ObservableNumberHandle : LOICollection::frontend::NativeHandle {
         std::unique_ptr<ll::ui::ObservableNumber> base;
+        using SubscriptionId = ll::ui::ObservableNumber::SubscriptionId;
+        std::vector<SubscriptionId> subscriptions;
+
+        void release() override {
+            if (this->base)
+                for (SubscriptionId id : this->subscriptions)
+                    this->base->unsubscribe(id);
+
+            this->subscriptions.clear();
+        }
+
+        ~ObservableNumberHandle() override { this->release(); }
     };
 
     void registerClasses(const std::string& name);

--- a/src/LOICollectionA/frontend/stdlib/ObservableStringClass.cpp
+++ b/src/LOICollectionA/frontend/stdlib/ObservableStringClass.cpp
@@ -62,7 +62,9 @@ namespace ObservableStringClass {
         if (func->argCount != 1)
             return ll::makeStringError("Subscribe function only needs one string parameter");
 
-        return static_cast<ObservableStringHandle*>(self->native.get())->base->subscribe([func, placeholders](const std::string& value) -> void {
+        auto* handle = static_cast<ObservableStringHandle*>(self->native.get());
+
+        auto id = handle->base->subscribe([func, placeholders](const std::string& value) -> void {
             DiagnosticEngine diagnostics;
 
             [[maybe_unused]] auto result = ir::VM::callFunctionRef(func, { value }, placeholders, diagnostics);
@@ -72,10 +74,18 @@ namespace ObservableStringClass {
                     ->error("ObservableString::subscribe callback: {}", diagnostics.getErrorMessage());
             }
         });
+
+        handle->subscriptions.push_back(id);
+        return id;
     }
 
     bool unsubscribe(const ObjectRef& self, const CallbackTypeValues& args) {
-        return static_cast<ObservableStringHandle*>(self->native.get())->base->unsubscribe(std::get<int>(args[0]));
+        auto* handle = static_cast<ObservableStringHandle*>(self->native.get());
+        auto id = static_cast<ObservableStringHandle::SubscriptionId>(std::get<int>(args[0]));
+
+        std::erase(handle->subscriptions, id);
+
+        return handle->base->unsubscribe(id);
     }
 
     void registerClasses(const std::string&) {
@@ -89,14 +99,14 @@ namespace ObservableStringClass {
         classes.registerMethod("ObservableString", "subscribe", subscribe, { ParamType::FUNCTION });
         classes.registerMethod("ObservableString", "unsubscribe", unsubscribe, { ParamType::INT });
 
-        // "obs + x" mirrors "getData() + x"; "obs == x" compares the stored text.
+        
         classes.registerOperator("ObservableString", "+", [](const TypedValue& left, const TypedValue& right) -> ll::Expected<TypedValue> {
             auto l = stringOperand(left);
             if (!l)
                 return ll::makeStringError("ObservableString operators require string operands");
 
-            /* Unwrap an ObservableString right side to its data; other types
-             * still stringify so "obs + number" keeps concatenating. */
+            
+
             if (auto r = stringOperand(right))
                 return *l + *r;
             return *l + ir::VM::valueToString(right);

--- a/src/LOICollectionA/frontend/stdlib/ObservableStringClass.h
+++ b/src/LOICollectionA/frontend/stdlib/ObservableStringClass.h
@@ -2,6 +2,7 @@
 
 #include <memory>
 #include <string>
+#include <vector>
 
 #include <ll/api/ui/base/Observable.h>
 
@@ -10,6 +11,18 @@
 namespace ObservableStringClass {
     struct ObservableStringHandle : LOICollection::frontend::NativeHandle {
         std::unique_ptr<ll::ui::ObservableString> base;
+        using SubscriptionId = ll::ui::ObservableString::SubscriptionId;
+        std::vector<SubscriptionId> subscriptions;
+
+        void release() override {
+            if (this->base)
+                for (SubscriptionId id : this->subscriptions)
+                    this->base->unsubscribe(id);
+
+            this->subscriptions.clear();
+        }
+
+        ~ObservableStringHandle() override { this->release(); }
     };
     
     void registerClasses(const std::string& name);

--- a/src/LOICollectionA/frontend/stdlib/ObservableUIRawMessageClass.cpp
+++ b/src/LOICollectionA/frontend/stdlib/ObservableUIRawMessageClass.cpp
@@ -75,8 +75,10 @@ namespace ObservableUIRawMessageClass {
         if (func->argCount != 1)
             return ll::makeStringError("Subscribe function only needs one bool parameter");
 
-        return static_cast<ObservableUIRawMessageHandle*>(self->native.get())->base->subscribe([
-            option = static_cast<ObservableUIRawMessageHandle*>(self->native.get())->base->isClientWritable(), func, placeholders
+        auto* owner = static_cast<ObservableUIRawMessageHandle*>(self->native.get());
+
+        auto id = owner->base->subscribe([
+            option = owner->base->isClientWritable(), func, placeholders
         ](const ll::ui::UIRawMessage& value) -> void {
             auto handle = std::make_shared<ObservableUIRawMessageHandle>();
             handle->base = std::make_unique<ll::ui::ObservableUIRawMessage>(
@@ -97,10 +99,18 @@ namespace ObservableUIRawMessageClass {
                     ->error("ObservableUIRawMessage::subscribe callback: {}", diagnostics.getErrorMessage());
             }
         });
+
+        owner->subscriptions.push_back(id);
+        return id;
     }
 
     bool unsubscribe(const ObjectRef& self, const CallbackTypeValues& args) {
-        return static_cast<ObservableUIRawMessageHandle*>(self->native.get())->base->unsubscribe(std::get<int>(args[0]));
+        auto* owner = static_cast<ObservableUIRawMessageHandle*>(self->native.get());
+        auto id = static_cast<ObservableUIRawMessageHandle::SubscriptionId>(std::get<int>(args[0]));
+
+        std::erase(owner->subscriptions, id);
+
+        return owner->base->unsubscribe(id);
     }
 
     void registerClasses(const std::string&) {

--- a/src/LOICollectionA/frontend/stdlib/ObservableUIRawMessageClass.h
+++ b/src/LOICollectionA/frontend/stdlib/ObservableUIRawMessageClass.h
@@ -2,6 +2,7 @@
 
 #include <memory>
 #include <string>
+#include <vector>
 
 #include <ll/api/ui/base/Observable.h>
 
@@ -10,6 +11,18 @@
 namespace ObservableUIRawMessageClass {
     struct ObservableUIRawMessageHandle : LOICollection::frontend::NativeHandle {
         std::unique_ptr<ll::ui::ObservableUIRawMessage> base;
+        using SubscriptionId = ll::ui::ObservableUIRawMessage::SubscriptionId;
+        std::vector<SubscriptionId> subscriptions;
+
+        void release() override {
+            if (this->base)
+                for (SubscriptionId id : this->subscriptions)
+                    this->base->unsubscribe(id);
+
+            this->subscriptions.clear();
+        }
+
+        ~ObservableUIRawMessageHandle() override { this->release(); }
     };
 
     void registerClasses(const std::string& name);

--- a/src/LOICollectionA/include/form/GUIManager.h
+++ b/src/LOICollectionA/include/form/GUIManager.h
@@ -78,6 +78,9 @@ namespace LOICollection::form {
         LOICOLLECTION_A_API   bool unregisterPaginatedFormUI(const std::string& id, Player& player);
         LOICOLLECTION_A_API   bool unregisterScriptFormUI(const std::string& id, Player& player);
 
+        LOICOLLECTION_A_API   void releasePlayerUI(Player& player);
+        LOICOLLECTION_A_API   void releaseAllUI();
+
         LOICOLLECTION_A_NDAPI ll::Expected<std::shared_ptr<CustomFormClass::CustomFormHandle>> getCustomFormUI(const std::string& id, Player& player);
         LOICOLLECTION_A_NDAPI ll::Expected<std::shared_ptr<MessageBoxClass::MessageBoxHandle>> getMessageBoxUI(const std::string& id, Player& player);
         LOICOLLECTION_A_NDAPI ll::Expected<std::shared_ptr<PaginatedFormClass::PaginatedFormHandle>> getPaginatedFormUI(const std::string& id, Player& player);

--- a/src/LOICollectionA/modules/form/GUIManager.cpp
+++ b/src/LOICollectionA/modules/form/GUIManager.cpp
@@ -42,6 +42,31 @@ namespace {
             ll::io::LoggerRegistry::getInstance().getOrCreate("LOICollectionA")
                 ->warn("script '{}' loaded without a permission entry — all capabilities denied", id);
     }
+
+    template <typename Registry>
+    bool eraseForm(Registry& registry, const std::string& uuid, const std::string& id) {
+        auto owner = registry.find(uuid);
+        if (owner == registry.end())
+            return false;
+
+        if (auto handle = owner->second.find(id); handle != owner->second.end())
+            handle->second->release();
+
+        owner->second.erase(id);
+        if (owner->second.empty())
+            registry.erase(owner);
+
+        return true;
+    }
+
+    template <typename Registry>
+    void releaseHandles(Registry& registry) {
+        for (auto& [_, handles] : registry)
+            for (auto& [_, handle] : handles)
+                handle->release();
+
+        registry.clear();
+    }
 }
 
 namespace LOICollection::form {
@@ -487,59 +512,46 @@ namespace LOICollection::form {
     }
 
     bool GUIManager::unregisterCustomFormUI(const std::string& id, Player& player) {
-        std::string uuid = player.getUuid().asString();
-
-        if (auto it = this->mImpl->forms.find(uuid); it != this->mImpl->forms.end()) {
-            it->second.erase(id);
-            if (it->second.empty())
-                this->mImpl->forms.erase(it);
-
-            return true;
-        }
-
-        return false;
+        return eraseForm(this->mImpl->forms, player.getUuid().asString(), id);
     }
 
     bool GUIManager::unregisterPaginatedFormUI(const std::string& id, Player& player) {
-        std::string uuid = player.getUuid().asString();
-
-        if (auto it = this->mImpl->paginatedForms.find(uuid); it != this->mImpl->paginatedForms.end()) {
-            it->second.erase(id);
-            if (it->second.empty())
-                this->mImpl->paginatedForms.erase(it);
-
-            return true;
-        }
-
-        return false;
+        return eraseForm(this->mImpl->paginatedForms, player.getUuid().asString(), id);
     }
 
     bool GUIManager::unregisterMessageBoxUI(const std::string& id, Player& player) {
-        std::string uuid = player.getUuid().asString();
-
-        if (auto it = this->mImpl->boxs.find(uuid); it != this->mImpl->boxs.end()) {
-            it->second.erase(id);
-            if (it->second.empty())
-                this->mImpl->boxs.erase(it);
-
-            return true;
-        }
-
-        return false;
+        return eraseForm(this->mImpl->boxs, player.getUuid().asString(), id);
     }
 
     bool GUIManager::unregisterScriptFormUI(const std::string& id, Player& player) {
-        std::string uuid = player.getUuid().asString();
+        return eraseForm(this->mImpl->scriptForms, player.getUuid().asString(), id);
+    }
 
-        if (auto it = this->mImpl->scriptForms.find(uuid); it != this->mImpl->scriptForms.end()) {
-            it->second.erase(id);
-            if (it->second.empty())
-                this->mImpl->scriptForms.erase(it);
+    void GUIManager::releasePlayerUI(Player& player) {
+        const std::string uuid = player.getUuid().asString();
 
-            return true;
-        }
+        auto drop = [&uuid](auto& registry) {
+            if (auto it = registry.find(uuid); it != registry.end()) {
+                for (auto& [_, handle] : it->second)
+                    handle->release();
 
-        return false;
+                registry.erase(it);
+            }
+        };
+
+        drop(this->mImpl->forms);
+        drop(this->mImpl->boxs);
+        drop(this->mImpl->paginatedForms);
+        drop(this->mImpl->scriptForms);
+    }
+
+    void GUIManager::releaseAllUI() {
+        this->mImpl->cache.clear();
+
+        releaseHandles(this->mImpl->forms);
+        releaseHandles(this->mImpl->boxs);
+        releaseHandles(this->mImpl->paginatedForms);
+        releaseHandles(this->mImpl->scriptForms);
     }
 
     ll::Expected<std::shared_ptr<CustomFormClass::CustomFormHandle>> GUIManager::getCustomFormUI(const std::string& id, Player& player) {

--- a/tests/common/frontend/LambdaTest.cpp
+++ b/tests/common/frontend/LambdaTest.cpp
@@ -65,6 +65,39 @@ TEST(LambdaTest, CaptureThis) {
         "3");
 }
 
+TEST(LambdaTest, CapturedObjectOutlivesCreatingFrame) {
+    EXPECT_EQ(eval(
+        "class A { "
+        "public: "
+        "x = 3; "
+        "} "
+        "cb = func () -> int { return 0; }; "
+        "func make(c) -> int { "
+        "cb = func () -> int { return c.x; }; "
+        "return 0; "
+        "} "
+        "make(new A()); "
+        "cb()"),
+        "3");
+}
+
+TEST(LambdaTest, CapturedThisOutlivesCreatingFrame) {
+    EXPECT_EQ(eval(
+        "cb = func () -> int { return 0; }; "
+        "class A { "
+        "public: "
+        "x = 3; "
+        "func make() -> int { "
+        "cb = func () -> int { return this.x; }; "
+        "return 0; "
+        "} "
+        "} "
+        "a = new A(); "
+        "a.make(); "
+        "cb()"),
+        "3");
+}
+
 TEST(LambdaTest, WrongArgumentCount) {
     EXPECT_THROW(eval("f = func (a: int) -> int { return a; }; f()"), std::runtime_error);
 }

--- a/tests/common/frontend/LoopTest.cpp
+++ b/tests/common/frontend/LoopTest.cpp
@@ -125,3 +125,57 @@ TEST(LoopTest, BreakOutsideLoopFails) {
 TEST(LoopTest, ContinueOutsideLoopFails) {
     EXPECT_THROW(eval("continue;"), std::runtime_error);
 }
+
+TEST(LoopTest, BreakInsideAnonFunctionFails) {
+    EXPECT_THROW(eval(
+        "for (i = 0; i < 3; i = i + 1) [ "
+        "    f = func () { break; }; "
+        "]"), std::runtime_error);
+}
+
+TEST(LoopTest, ContinueInsideAnonFunctionFails) {
+    EXPECT_THROW(eval(
+        "while (true) [ "
+        "    f = func () { continue; }; "
+        "    break; "
+        "]"), std::runtime_error);
+}
+
+TEST(LoopTest, BreakInsideNamedFunctionFails) {
+    EXPECT_THROW(eval(
+        "while (true) [ "
+        "    func inner() { break; }; "
+        "    break; "
+        "]"), std::runtime_error);
+}
+
+TEST(LoopTest, LoopInsideAnonFunctionIsIsolated) {
+    EXPECT_EQ(eval(
+        "f = func () -> int { "
+        "    s = 0; "
+        "    for (j = 0; j < 10; j = j + 1) [ "
+        "        if (j == 3) [ break; ]; "
+        "        s = s + j; "
+        "    ]; "
+        "    return s; "
+        "}; "
+        "f()"), "3");
+}
+
+TEST(LoopTest, LoopInsideClassMethodIsIsolated) {
+    EXPECT_EQ(eval(
+        "class Counter { "
+        "public: "
+        "func sum() -> int { "
+        "    s = 0; "
+        "    i = 0; "
+        "    while (i < 10) [ "
+        "        i = i + 1; "
+        "        if (i == 4) [ break; ]; "
+        "        s = s + i; "
+        "    ]; "
+        "    return s; "
+        "} "
+        "} "
+        "new Counter().sum()"), "6");
+}

--- a/tests/common/frontend/ReceiverBindingTest.cpp
+++ b/tests/common/frontend/ReceiverBindingTest.cpp
@@ -1,0 +1,143 @@
+#include <gtest/gtest.h>
+
+#include "common/frontend/CommonTest.h"
+
+using namespace LOICollection::frontend;
+
+TEST(ReceiverBindingTest, ThisRefersToCallReceiver) {
+    EXPECT_EQ(eval(
+        "class Box { "
+        "public: "
+        "v = 41; "
+        "func run(cb) { return cb(); } "
+        "} "
+        "b = new Box(); "
+        "b.run(func () -> int { return this.v + 1; })"),
+        "42");
+}
+
+TEST(ReceiverBindingTest, CapturingReceiverIsRejected) {
+    try {
+        eval(
+            "class Box { "
+            "public: "
+            "v = 41; "
+            "func run(cb) { return cb(); } "
+            "} "
+            "b = new Box(); "
+            "b.run(func () -> int { return b.v + 1; })");
+        FAIL() << "capturing the receiver inside a callback must be rejected";
+    } catch (const std::runtime_error& error) {
+        EXPECT_NE(std::string(error.what()).find("captures its receiver"), std::string::npos);
+    }
+}
+
+TEST(ReceiverBindingTest, CapturingReceiverInNestedClosureIsRejected) {
+    try {
+        eval(
+            "class Box { "
+            "public: "
+            "v = 41; "
+            "func run(cb) { return cb(); } "
+            "} "
+            "b = new Box(); "
+            "b.run(func () -> int { return b.run(func () -> int { return b.v; }); })");
+        FAIL() << "capturing the receiver from a nested closure must be rejected";
+    } catch (const std::runtime_error& error) {
+        EXPECT_NE(std::string(error.what()).find("captures its receiver"), std::string::npos);
+    }
+}
+
+TEST(ReceiverBindingTest, UnrelatedObjectIsStillCapturable) {
+    EXPECT_EQ(eval(
+        "class Box { "
+        "public: "
+        "v = 41; "
+        "func run(cb) { return cb(); } "
+        "} "
+        "b = new Box(); "
+        "other = new Box(); "
+        "other.v = 1; "
+        "b.run(func () -> int { return other.v + this.v; })"),
+        "42");
+}
+
+TEST(ReceiverBindingTest, NestedClosureBindsInnermostReceiver) {
+    EXPECT_EQ(eval(
+        "class Outer { "
+        "public: "
+        "v = 1; "
+        "func run(cb) { return cb(); } "
+        "} "
+        "class Inner { "
+        "public: "
+        "v = 2; "
+        "func run(cb) { return cb(); } "
+        "} "
+        "a = new Outer(); "
+        "b = new Inner(); "
+        "a.run(func () -> int { return this.v + b.run(func () -> int { return this.v; }); })"),
+        "3");
+}
+
+TEST(ReceiverBindingTest, MethodReceiverIsNotRebound) {
+    EXPECT_EQ(eval(
+        "class Outer { "
+        "public: "
+        "v = 10; "
+        "func run(cb) { return cb(); } "
+        "} "
+        "class Holder { "
+        "public: "
+        "v = 32; "
+        "func fetch(target: Outer) { return target.run(func () -> int { return this.v; }); } "
+        "} "
+        "new Holder().fetch(new Outer())"),
+        "32");
+}
+
+TEST(ReceiverBindingTest, BoundCallbackDoesNotRetainReceiver) {
+    DiagnosticEngine diagnostics;
+    auto chunk = compile(
+        "class Box { "
+        "public: "
+        "v = 7; "
+        "cb = 0; "
+        "func keep(c) { this.cb = c; } "
+        "} "
+        "b = new Box(); "
+        "b.keep(func () -> int { return this.v; }); "
+        "b",
+        diagnostics);
+    ASSERT_NE(chunk, nullptr);
+
+    std::weak_ptr<Object> watched;
+    {
+        ir::VM vm(diagnostics);
+        auto result = vm.run(chunk, {});
+        ASSERT_FALSE(diagnostics.hasErrors());
+        ASSERT_TRUE(std::holds_alternative<ObjectRef>(result));
+
+        watched = std::get<ObjectRef>(result);
+    }
+
+    EXPECT_TRUE(watched.expired());
+}
+
+TEST(ReceiverBindingTest, CallbackDoesNotRetainGlobals) {
+    DiagnosticEngine diagnostics;
+    auto chunk = compile("g = 1; f = func () -> int { return g; }; f", diagnostics);
+    ASSERT_NE(chunk, nullptr);
+
+    FunctionRefPtr func;
+    {
+        ir::VM vm(diagnostics);
+        auto result = vm.run(chunk, {});
+        ASSERT_FALSE(diagnostics.hasErrors());
+        ASSERT_TRUE(std::holds_alternative<FunctionRefPtr>(result));
+
+        func = std::get<FunctionRefPtr>(result);
+    }
+
+    EXPECT_TRUE(func->globals.expired());
+}


### PR DESCRIPTION
- weaken FunctionRef::thisObj and globals to weak refs (borrowed/shared edges)
- method-call receiver binds to callback `this` at registration point
- static analysis rejects closures that capture their receiver by variable (forces `this`), turning the old write-style into a compile-time error
- GUIManager releases native handles on form teardown to stop host cycles
- add ReceiverBindingTest covering reject/accept/nested/unretained cases