### PR TITLE
Optimizer passes and VM execution-layer performance work

### DIFF
--- a/src/LOICollectionA/frontend/AST.h
+++ b/src/LOICollectionA/frontend/AST.h
@@ -907,41 +907,67 @@ namespace LOICollection::frontend {
 
         void adoptLayout();
 
+        [[nodiscard]] int slotOf(const std::string& name) const {
+            return this->layout ? this->layout->slotOf(name) : -1;
+        }
+
+        [[nodiscard]] ValueNode::ValueType* declaredAt(int slot) {
+            return slot < 0 || static_cast<size_t>(slot) >= this->slots.size()
+                ? nullptr
+                : &this->slots[static_cast<size_t>(slot)];
+        }
+
+        [[nodiscard]] const ValueNode::ValueType* declaredAt(int slot) const {
+            return slot < 0 || static_cast<size_t>(slot) >= this->slots.size()
+                ? nullptr
+                : &this->slots[static_cast<size_t>(slot)];
+        }
+
+        [[nodiscard]] ValueNode::ValueType* fieldAt(int slot, const std::string& name) {
+            if (ValueNode::ValueType* declared = this->declaredAt(slot))
+                return declared;
+
+            if (!this->spill)
+                return nullptr;
+
+            auto it = this->spill->find(name);
+            return it == this->spill->end() ? nullptr : &it->second;
+        }
+
+        [[nodiscard]] const ValueNode::ValueType* fieldAt(int slot, const std::string& name) const {
+            if (const ValueNode::ValueType* declared = this->declaredAt(slot))
+                return declared;
+
+            if (!this->spill)
+                return nullptr;
+
+            auto it = this->spill->find(name);
+            return it == this->spill->end() ? nullptr : &it->second;
+        }
+
+        [[nodiscard]] ValueNode::ValueType& fieldAtOrSpill(int slot, const std::string& name) {
+            if (ValueNode::ValueType* declared = this->declaredAt(slot))
+                return *declared;
+
+            return this->spillSlot(name);
+        }
+
         void assign(const std::string& name, ValueNode::ValueType value) {
             if (!this->layout)
                 this->adoptLayout();
 
-            if (ValueNode::ValueType* slot = this->findDeclared(name)) {
-                *slot = std::move(value);
-                return;
-            }
-
-            this->spillSlot(name) = std::move(value);
+            this->fieldAtOrSpill(this->slotOf(name), name) = std::move(value);
         }
 
         [[nodiscard]] ValueNode::ValueType* find(const std::string& name) {
             if (!this->layout)
                 this->adoptLayout();
 
-            if (ValueNode::ValueType* slot = this->findDeclared(name))
-                return slot;
-
-            if (!this->spill)
-                return nullptr;
-
-            auto it = this->spill->find(name);
-            return it == this->spill->end() ? nullptr : &it->second;
+            return this->fieldAt(this->slotOf(name), name);
         }
 
         [[nodiscard]] const ValueNode::ValueType* find(const std::string& name) const {
-            if (const ValueNode::ValueType* slot = this->findDeclared(name))
-                return slot;
-
-            if (!this->spill)
-                return nullptr;
-
-            auto it = this->spill->find(name);
-            return it == this->spill->end() ? nullptr : &it->second;
+            return this->fieldAt(this->slotOf(name), name);
         }
 
         [[nodiscard]] ValueNode::ValueType& at(const std::string& name) {
@@ -952,20 +978,6 @@ namespace LOICollection::frontend {
         }
 
     private:
-        [[nodiscard]] ValueNode::ValueType* findDeclared(const std::string& name) {
-            int index = this->layout ? this->layout->slotOf(name) : -1;
-            return index < 0 || static_cast<size_t>(index) >= this->slots.size()
-                ? nullptr
-                : &this->slots[static_cast<size_t>(index)];
-        }
-
-        [[nodiscard]] const ValueNode::ValueType* findDeclared(const std::string& name) const {
-            int index = this->layout ? this->layout->slotOf(name) : -1;
-            return index < 0 || static_cast<size_t>(index) >= this->slots.size()
-                ? nullptr
-                : &this->slots[static_cast<size_t>(index)];
-        }
-
         ValueNode::ValueType& spillSlot(const std::string& name) {
             if (!this->spill)
                 this->spill = std::make_unique<SpillMap>();

--- a/src/LOICollectionA/frontend/Callback.cpp
+++ b/src/LOICollectionA/frontend/Callback.cpp
@@ -65,8 +65,8 @@ namespace LOICollection::frontend {
     std::vector<ParamType> valuesToTypes(const CallbackTypeValues& values, DiagnosticEngine& diagnostics, const SourceLocation& loc) {
         std::vector<ParamType> argTypes;
         for (const auto& arg : values) {
-            std::visit([&argTypes, &diagnostics, &loc](auto&& arg) {
-                using T = std::decay_t<decltype(arg)>;
+            std::visit([&argTypes, &diagnostics, &loc](auto&& value) {
+                using T = std::decay_t<decltype(value)>;
 
                 if constexpr (std::is_same_v<T, int>)
                     argTypes.push_back(ParamType::INT);

--- a/src/LOICollectionA/frontend/Lexer.cpp
+++ b/src/LOICollectionA/frontend/Lexer.cpp
@@ -90,8 +90,7 @@ namespace LOICollection::frontend {
                         return parseNumber();
 
                     if (peekChar() == '.') {
-                        /* "1...10" would otherwise lex as "1", "..", ".10" and
-                         * fail later with a misleading message — reject it here. */
+                        
                         if (position + 2 < input.size() && input[position + 2] == '.') {
                             diagnostics.addError({line, column, position},
                                 "Unexpected '...' (a range uses exactly two dots: '..')");

--- a/src/LOICollectionA/frontend/ir/ByteCode.h
+++ b/src/LOICollectionA/frontend/ir/ByteCode.h
@@ -13,7 +13,7 @@ namespace LOICollection::frontend::ir {
         OpCode op;
 
         int operand;
-        SourceLocation loc;
+        SourceLocation loc{};
     };
 
     struct FuncMeta {

--- a/src/LOICollectionA/frontend/ir/ByteCode.h
+++ b/src/LOICollectionA/frontend/ir/ByteCode.h
@@ -96,11 +96,7 @@ namespace LOICollection::frontend::ir {
         std::vector<ByNameCallMeta> byNameCalls;
         std::vector<SuperCallMeta> superCalls;
         std::vector<LambdaMeta> lambdas;
-        /* Deque of owners on purpose: the compiler keeps `current` references
-         * into nested bodies while appending siblings, so references must stay
-         * valid across push_back. The bodies are held by unique_ptr because
-         * MSVC STL's std::deque does not support an incomplete value type
-         * (a self-referencing member), while libstdc++ accepts it. */
+        
         std::deque<std::unique_ptr<BytecodeChunk>> methodBodies;
 
         int slotCount = 0;

--- a/src/LOICollectionA/frontend/ir/BytecodeSerializer.cpp
+++ b/src/LOICollectionA/frontend/ir/BytecodeSerializer.cpp
@@ -36,7 +36,7 @@ namespace LOICollection::frontend::ir {
 
         class Reader {
         public:
-            explicit Reader(const std::string& blob) : blob(blob) {}
+            explicit Reader(const std::string& data) : blob(data) {}
 
             bool raw(void* out, size_t size) {
                 if (this->pos + size > this->blob.size())

--- a/src/LOICollectionA/frontend/ir/Compiler.cpp
+++ b/src/LOICollectionA/frontend/ir/Compiler.cpp
@@ -55,13 +55,13 @@ namespace LOICollection::frontend::ir {
             }
 
             for (auto node : this->bodyOrder) {
-                ASTNode& current = node.get();
-                switch (current.getType()) {
+                ASTNode& target = node.get();
+                switch (target.getType()) {
                     case ASTNode::Type::Class:
-                        this->compileClassBodies(static_cast<ClassNode&>(current));
+                        this->compileClassBodies(static_cast<ClassNode&>(target));
                         break;
                     case ASTNode::Type::FunctionDef:
-                        this->compileFunctionBody(static_cast<FunctionDefNode&>(current));
+                        this->compileFunctionBody(static_cast<FunctionDefNode&>(target));
                         break;
                     default:
                         break;
@@ -180,7 +180,7 @@ namespace LOICollection::frontend::ir {
                     this->current.get().emit(OpCode::UNWRAP, 0, node.loc);
 
                 this->compileValue(*node.value, node.loc);
-                this->emitArithmeticOp(node.op, node.loc);
+                this->emitArithmeticOp(node.op, var.type, node.value->type, node.loc);
 
                 this->current.get().emit(OpCode::DUP, 0, node.loc);
                 this->emitStore(name, node.loc);
@@ -196,7 +196,7 @@ namespace LOICollection::frontend::ir {
                         this->current.get().emit(OpCode::UNWRAP, 0, node.loc);
 
                     this->compileValue(*node.value, node.loc);
-                    this->emitArithmeticOp(node.op, node.loc);
+                    this->emitArithmeticOp(node.op, member.type, node.value->type, node.loc);
 
                     this->current.get().emit(OpCode::DUP, 0, node.loc);
                     this->emitStore(name, node.loc);
@@ -211,7 +211,7 @@ namespace LOICollection::frontend::ir {
                     this->current.get().emit(OpCode::UNWRAP, 0, node.loc);
 
                 this->compileValue(*node.value, node.loc);
-                this->emitArithmeticOp(node.op, node.loc);
+                this->emitArithmeticOp(node.op, member.type, node.value->type, node.loc);
 
                 this->current.get().emit(OpCode::DUP, 0, node.loc);
                 this->current.get().emit(OpCode::ROT3, 0, node.loc);
@@ -228,7 +228,7 @@ namespace LOICollection::frontend::ir {
                 this->current.get().emit(OpCode::LOAD_INDEX, 0, node.loc);
 
                 this->compileValue(*node.value, node.loc);
-                this->emitArithmeticOp(node.op, node.loc);
+                this->emitArithmeticOp(node.op, indexNode.type, node.value->type, node.loc);
 
                 this->current.get().emit(OpCode::DUP, 0, node.loc);
                 this->current.get().emit(OpCode::SWAP2, 0, node.loc);
@@ -282,12 +282,15 @@ namespace LOICollection::frontend::ir {
             this->compileForInIterable(node, uid, *protocol);
     }
 
-    void Compiler::emitArithmeticOp(const std::string& op, const SourceLocation& loc) {
-        if (op == "+") this->current.get().emit(OpCode::ADD, 0, loc);
-        else if (op == "-") this->current.get().emit(OpCode::SUB, 0, loc);
-        else if (op == "*") this->current.get().emit(OpCode::MUL, 0, loc);
+    void Compiler::emitArithmeticOp(const std::string& op, const TypeInfo& leftType, const TypeInfo& rightType, const SourceLocation& loc) {
+        const bool intOp = (op == "+" || op == "-" || op == "*" || op == "%") &&
+            leftType.kind == TypeKind::Int && rightType.kind == TypeKind::Int;
+
+        if (op == "+") this->current.get().emit(intOp ? OpCode::ADD_I : OpCode::ADD, 0, loc);
+        else if (op == "-") this->current.get().emit(intOp ? OpCode::SUB_I : OpCode::SUB, 0, loc);
+        else if (op == "*") this->current.get().emit(intOp ? OpCode::MUL_I : OpCode::MUL, 0, loc);
         else if (op == "/") this->current.get().emit(OpCode::DIV, 0, loc);
-        else if (op == "%") this->current.get().emit(OpCode::MOD, 0, loc);
+        else if (op == "%") this->current.get().emit(intOp ? OpCode::MOD_I : OpCode::MOD, 0, loc);
         else
             this->diagnostics.addError(loc, "Unknown compound assignment op: " + op);
     }
@@ -416,12 +419,14 @@ namespace LOICollection::frontend::ir {
         this->compileValue(*node.left, node.loc);
         this->compileValue(*node.right, node.loc);
 
-        if (node.op == "==") this->current.get().emit(OpCode::CMP_EQ, 0, node.loc);
-        else if (node.op == "!=") this->current.get().emit(OpCode::CMP_NE, 0, node.loc);
-        else if (node.op == ">") this->current.get().emit(OpCode::CMP_GT, 0, node.loc);
-        else if (node.op == "<") this->current.get().emit(OpCode::CMP_LT, 0, node.loc);
-        else if (node.op == ">=") this->current.get().emit(OpCode::CMP_GE, 0, node.loc);
-        else if (node.op == "<=") this->current.get().emit(OpCode::CMP_LE, 0, node.loc);
+        const bool intOp = node.left->type.kind == TypeKind::Int && node.right->type.kind == TypeKind::Int;
+
+        if (node.op == "==") this->current.get().emit(intOp ? OpCode::CMP_EQ_I : OpCode::CMP_EQ, 0, node.loc);
+        else if (node.op == "!=") this->current.get().emit(intOp ? OpCode::CMP_NE_I : OpCode::CMP_NE, 0, node.loc);
+        else if (node.op == ">") this->current.get().emit(intOp ? OpCode::CMP_GT_I : OpCode::CMP_GT, 0, node.loc);
+        else if (node.op == "<") this->current.get().emit(intOp ? OpCode::CMP_LT_I : OpCode::CMP_LT, 0, node.loc);
+        else if (node.op == ">=") this->current.get().emit(intOp ? OpCode::CMP_GE_I : OpCode::CMP_GE, 0, node.loc);
+        else if (node.op == "<=") this->current.get().emit(intOp ? OpCode::CMP_LE_I : OpCode::CMP_LE, 0, node.loc);
         else
             this->diagnostics.addError(node.loc, "Unknown compare op: " + node.op);
     }
@@ -506,11 +511,14 @@ namespace LOICollection::frontend::ir {
         this->compileValue(*node.left, node.loc);
         this->compileValue(*node.right, node.loc);
 
-        if (node.op == "+") this->current.get().emit(OpCode::ADD, 0, node.loc);
-        else if (node.op == "-") this->current.get().emit(OpCode::SUB, 0, node.loc);
-        else if (node.op == "*") this->current.get().emit(OpCode::MUL, 0, node.loc);
+        const bool intOp = (node.op == "+" || node.op == "-" || node.op == "*" || node.op == "%") &&
+            node.left->type.kind == TypeKind::Int && node.right->type.kind == TypeKind::Int;
+
+        if (node.op == "+") this->current.get().emit(intOp ? OpCode::ADD_I : OpCode::ADD, 0, node.loc);
+        else if (node.op == "-") this->current.get().emit(intOp ? OpCode::SUB_I : OpCode::SUB, 0, node.loc);
+        else if (node.op == "*") this->current.get().emit(intOp ? OpCode::MUL_I : OpCode::MUL, 0, node.loc);
         else if (node.op == "/") this->current.get().emit(OpCode::DIV, 0, node.loc);
-        else if (node.op == "%") this->current.get().emit(OpCode::MOD, 0, node.loc);
+        else if (node.op == "%") this->current.get().emit(intOp ? OpCode::MOD_I : OpCode::MOD, 0, node.loc);
         else if (node.op == "^") this->current.get().emit(OpCode::POW, 0, node.loc);
         else
             this->diagnostics.addError(node.loc, "Unknown arithmetic op: " + node.op);
@@ -519,7 +527,9 @@ namespace LOICollection::frontend::ir {
     void Compiler::visit(UnaryNode& node) {
         this->compileValue(*node.operand, node.loc);
 
-        if (node.op == "-") this->current.get().emit(OpCode::NEG, 0, node.loc);
+        if (node.op == "-")
+            this->current.get().emit(
+                node.operand->type.kind == TypeKind::Int ? OpCode::NEG_I : OpCode::NEG, 0, node.loc);
         else if (node.op == "!") this->current.get().emit(OpCode::NOT, 0, node.loc);
         else if (node.op == "+") {}
         else

--- a/src/LOICollectionA/frontend/ir/Compiler.h
+++ b/src/LOICollectionA/frontend/ir/Compiler.h
@@ -113,7 +113,7 @@ namespace LOICollection::frontend::ir {
         void compileForInIterable(ForInNode& node, size_t uid, const IterableProtocol& protocol);
         void emitIterableLength(const IterableProtocol& protocol, int seqSlot, const SourceLocation& loc);
         void emitIterableElement(const IterableProtocol& protocol, int seqSlot, int idxSlot, const SourceLocation& loc);
-        void emitArithmeticOp(const std::string& op, const SourceLocation& loc);
+        void emitArithmeticOp(const std::string& op, const TypeInfo& leftType, const TypeInfo& rightType, const SourceLocation& loc);
 
         void desugarDeclarativeStatements(std::unique_ptr<ASTNode>& node, const std::string& receiver);
         void compileDeclarativeBlock(BlockNode& block, const std::string& receiverName);

--- a/src/LOICollectionA/frontend/ir/OpCode.h
+++ b/src/LOICollectionA/frontend/ir/OpCode.h
@@ -50,6 +50,10 @@ namespace LOICollection::frontend::ir {
         LOAD_FIELD_SLOT,
         STORE_FIELD_SLOT,
 
+        ADD_I, SUB_I, MUL_I, MOD_I,
+        CMP_EQ_I, CMP_NE_I, CMP_GT_I, CMP_LT_I, CMP_GE_I, CMP_LE_I,
+        NEG_I,
+
         COUNT
     };
 }

--- a/src/LOICollectionA/frontend/ir/Optimizer.cpp
+++ b/src/LOICollectionA/frontend/ir/Optimizer.cpp
@@ -25,9 +25,6 @@ namespace LOICollection::frontend::ir {
         return total;
     }
 
-    // Repeat the single pass until it stops making progress: each round's rewrites
-    // (forwarded loads, folded branches, dropped operands) expose new opportunities
-    // for the next round. A pass that changes nothing means the chunk is stable.
     Optimizer::Stats Optimizer::optimizeChunk(BytecodeChunk& chunk) {
         Stats total;
 

--- a/src/LOICollectionA/frontend/ir/Optimizer.cpp
+++ b/src/LOICollectionA/frontend/ir/Optimizer.cpp
@@ -28,9 +28,6 @@ namespace LOICollection::frontend::ir {
     // Repeat the single pass until it stops making progress: each round's rewrites
     // (forwarded loads, folded branches, dropped operands) expose new opportunities
     // for the next round. A pass that changes nothing means the chunk is stable.
-    // Hoisting runs after the fixpoint so that loops which turn out to be dead are
-    // already gone, and runs before a last fixpoint so the peephole passes can tidy
-    // up the DUP/POP pair the hoist leaves around the loop.
     Optimizer::Stats Optimizer::optimizeChunk(BytecodeChunk& chunk) {
         Stats total;
 

--- a/src/LOICollectionA/frontend/ir/Optimizer.cpp
+++ b/src/LOICollectionA/frontend/ir/Optimizer.cpp
@@ -4,6 +4,7 @@
 #include "LOICollectionA/frontend/ir/opt/passes/DeadCodePass.h"
 #include "LOICollectionA/frontend/ir/opt/passes/DeadStorePass.h"
 #include "LOICollectionA/frontend/ir/opt/passes/LICMPass.h"
+#include "LOICollectionA/frontend/ir/opt/passes/CSEPass.h"
 
 #include "LOICollectionA/frontend/ir/Optimizer.h"
 
@@ -75,6 +76,11 @@ namespace LOICollection::frontend::ir {
 
         opt::DeadCodePass deadPass;
         deadPass.run(chunk, ctx, this->enabled(Pass::DeadCode));
+
+        opt::CSEPass csePass{ chunk };
+        if (this->enabled(Pass::CSE)) {
+            ctx.stats.removed += csePass.run();
+        }
 
         return ctx.stats;
     }

--- a/src/LOICollectionA/frontend/ir/Optimizer.cpp
+++ b/src/LOICollectionA/frontend/ir/Optimizer.cpp
@@ -3,6 +3,7 @@
 #include "LOICollectionA/frontend/ir/opt/passes/ConstantFoldPass.h"
 #include "LOICollectionA/frontend/ir/opt/passes/DeadCodePass.h"
 #include "LOICollectionA/frontend/ir/opt/passes/DeadStorePass.h"
+#include "LOICollectionA/frontend/ir/opt/passes/LICMPass.h"
 
 #include "LOICollectionA/frontend/ir/Optimizer.h"
 
@@ -26,8 +27,25 @@ namespace LOICollection::frontend::ir {
     // Repeat the single pass until it stops making progress: each round's rewrites
     // (forwarded loads, folded branches, dropped operands) expose new opportunities
     // for the next round. A pass that changes nothing means the chunk is stable.
+    // Hoisting runs after the fixpoint so that loops which turn out to be dead are
+    // already gone, and runs before a last fixpoint so the peephole passes can tidy
+    // up the DUP/POP pair the hoist leaves around the loop.
     Optimizer::Stats Optimizer::optimizeChunk(BytecodeChunk& chunk) {
         Stats total;
+
+        for (int pass = 0; pass < 16; ++pass) {
+            Stats once = this->optimizeChunkOnce(chunk);
+            total.folded += once.folded;
+            total.removed += once.removed;
+
+            if (once.folded == 0 && once.removed == 0)
+                break;
+        }
+
+        if (this->enabled(Pass::LICM)) {
+            opt::LICMPass licm{ chunk };
+            licm.run();
+        }
 
         for (int pass = 0; pass < 16; ++pass) {
             Stats once = this->optimizeChunkOnce(chunk);

--- a/src/LOICollectionA/frontend/ir/Optimizer.cpp
+++ b/src/LOICollectionA/frontend/ir/Optimizer.cpp
@@ -2,6 +2,7 @@
 #include "LOICollectionA/frontend/ir/opt/analysis/JumpTargetAnalysis.h"
 #include "LOICollectionA/frontend/ir/opt/passes/ConstantFoldPass.h"
 #include "LOICollectionA/frontend/ir/opt/passes/DeadCodePass.h"
+#include "LOICollectionA/frontend/ir/opt/passes/DeadStorePass.h"
 
 #include "LOICollectionA/frontend/ir/Optimizer.h"
 
@@ -50,6 +51,9 @@ namespace LOICollection::frontend::ir {
 
         opt::ConstantFoldPass foldPass{ chunk, ctx, jumps };
         foldPass.run(this->enabled(Pass::ConstantFold));
+
+        opt::DeadStorePass storePass{ chunk, ctx, jumps };
+        storePass.run(this->enabled(Pass::DeadStore));
 
         opt::DeadCodePass deadPass;
         deadPass.run(chunk, ctx, this->enabled(Pass::DeadCode));

--- a/src/LOICollectionA/frontend/ir/Optimizer.h
+++ b/src/LOICollectionA/frontend/ir/Optimizer.h
@@ -12,13 +12,15 @@ namespace LOICollection::frontend::ir {
         enum class Pass : unsigned {
             ConstantFold = 1u << 0,
             DeadCode = 1u << 1,
-            DeadStore = 1u << 2
+            DeadStore = 1u << 2,
+            LICM = 1u << 3
         };
 
         static constexpr unsigned allPasses =
             static_cast<unsigned>(Pass::ConstantFold) |
             static_cast<unsigned>(Pass::DeadCode) |
-            static_cast<unsigned>(Pass::DeadStore);
+            static_cast<unsigned>(Pass::DeadStore) |
+            static_cast<unsigned>(Pass::LICM);
 
         struct Stats {
             size_t folded = 0;

--- a/src/LOICollectionA/frontend/ir/Optimizer.h
+++ b/src/LOICollectionA/frontend/ir/Optimizer.h
@@ -13,14 +13,16 @@ namespace LOICollection::frontend::ir {
             ConstantFold = 1u << 0,
             DeadCode = 1u << 1,
             DeadStore = 1u << 2,
-            LICM = 1u << 3
+            LICM = 1u << 3,
+            CSE = 1u << 4
         };
 
         static constexpr unsigned allPasses =
             static_cast<unsigned>(Pass::ConstantFold) |
             static_cast<unsigned>(Pass::DeadCode) |
             static_cast<unsigned>(Pass::DeadStore) |
-            static_cast<unsigned>(Pass::LICM);
+            static_cast<unsigned>(Pass::LICM) |
+            static_cast<unsigned>(Pass::CSE);
 
         struct Stats {
             size_t folded = 0;

--- a/src/LOICollectionA/frontend/ir/Optimizer.h
+++ b/src/LOICollectionA/frontend/ir/Optimizer.h
@@ -11,10 +11,14 @@ namespace LOICollection::frontend::ir {
     public:
         enum class Pass : unsigned {
             ConstantFold = 1u << 0,
-            DeadCode = 1u << 1
+            DeadCode = 1u << 1,
+            DeadStore = 1u << 2
         };
 
-        static constexpr unsigned allPasses = static_cast<unsigned>(Pass::ConstantFold) | static_cast<unsigned>(Pass::DeadCode);
+        static constexpr unsigned allPasses =
+            static_cast<unsigned>(Pass::ConstantFold) |
+            static_cast<unsigned>(Pass::DeadCode) |
+            static_cast<unsigned>(Pass::DeadStore);
 
         struct Stats {
             size_t folded = 0;

--- a/src/LOICollectionA/frontend/ir/VM.cpp
+++ b/src/LOICollectionA/frontend/ir/VM.cpp
@@ -70,6 +70,7 @@ namespace LOICollection::frontend::ir {
 
         this->stack.clear();
         this->frames.clear();
+        this->localPool.clear();
         this->globals->clear();
         this->mReport = sandbox::SandboxReport{};
 
@@ -83,6 +84,7 @@ namespace LOICollection::frontend::ir {
         }
 
         this->frames.emplace_back(*chunk);
+        this->localPool.resize(chunk->slotCount);
 
         CallbackTypePlaces placeholders = ctx.params;
         if (!ctx.scriptId.empty())
@@ -166,6 +168,7 @@ namespace LOICollection::frontend::ir {
 
                     Frame finished = std::move(this->frames.back());
                     this->frames.pop_back();
+                    this->localPool.resize(finished.localsBase);
 
                     if (this->frames.empty())
                         return result;
@@ -279,15 +282,16 @@ namespace LOICollection::frontend::ir {
         }
 
         const size_t paramBase = func->captures.size();
-        if (paramBase + static_cast<size_t>(func->argCount) > callee.locals.size()) {
+        if (paramBase + static_cast<size_t>(func->argCount) > callee.localsSize) {
             diagnostics.addError({}, "Lambda frame is too small for its parameters");
             return std::monostate{};
         }
 
-        std::copy_n(func->captures.begin(), paramBase, callee.locals.begin());
+        vm.localPool.resize(callee.localsSize);
+        std::copy_n(func->captures.begin(), paramBase, vm.localPool.begin());
 
         for (int i = 0; i < func->argCount; ++i)
-            callee.locals[paramBase + i] = args[i];
+            vm.localPool[paramBase + i] = args[i];
 
         vm.frames.push_back(std::move(callee));
         return vm.execute(func->owner, placeholders);

--- a/src/LOICollectionA/frontend/ir/VM.cpp
+++ b/src/LOICollectionA/frontend/ir/VM.cpp
@@ -158,9 +158,13 @@ namespace LOICollection::frontend::ir {
                 case OpCode::CALL_METHOD: case OpCode::CALL_METHOD_VIRTUAL: case OpCode::CALL_METHOD_BY_NAME: case OpCode::CALL_SUPER_CTOR: this->execMethodDispatch(s); break;
                 case OpCode::CALL_NATIVE_METHOD: this->execNativeCall(s); break;
                 case OpCode::CALL_FUNC: case OpCode::CALL_LAMBDA: this->execFunctionCall(s); break;
-                case OpCode::ADD: case OpCode::SUB: case OpCode::MUL: case OpCode::DIV: case OpCode::MOD: case OpCode::POW: this->execArithmetic(s); break;
-                case OpCode::CMP_EQ: case OpCode::CMP_NE: case OpCode::CMP_GT: case OpCode::CMP_LT: case OpCode::CMP_GE: case OpCode::CMP_LE: this->execComparison(s); break;
-                case OpCode::LOGIC_AND: case OpCode::LOGIC_OR: case OpCode::NEG: case OpCode::NOT: this->execLogic(s); break;
+                case OpCode::ADD: case OpCode::SUB: case OpCode::MUL: case OpCode::DIV: case OpCode::MOD: case OpCode::POW:
+                case OpCode::ADD_I: case OpCode::SUB_I: case OpCode::MUL_I: case OpCode::MOD_I:
+                    this->execArithmetic(s); break;
+                case OpCode::CMP_EQ: case OpCode::CMP_NE: case OpCode::CMP_GT: case OpCode::CMP_LT: case OpCode::CMP_GE: case OpCode::CMP_LE:
+                case OpCode::CMP_EQ_I: case OpCode::CMP_NE_I: case OpCode::CMP_GT_I: case OpCode::CMP_LT_I: case OpCode::CMP_GE_I: case OpCode::CMP_LE_I:
+                    this->execComparison(s); break;
+                case OpCode::LOGIC_AND: case OpCode::LOGIC_OR: case OpCode::NEG: case OpCode::NOT: case OpCode::NEG_I: this->execLogic(s); break;
                 case OpCode::CALL: case OpCode::CALL_MACRO: this->execHostCall(s); break;
                 case OpCode::JMP_IF_FALSE: case OpCode::JMP_IF_TRUE: case OpCode::JMP: this->execBranch(s); break;
                 case OpCode::RETURN: {

--- a/src/LOICollectionA/frontend/ir/VM.cpp
+++ b/src/LOICollectionA/frontend/ir/VM.cpp
@@ -208,17 +208,17 @@ namespace LOICollection::frontend::ir {
         Frame& frame = s.frame;
         switch (instr.op) {
             case OpCode::JMP_IF_FALSE: {
-                    auto cond = this->pop();
-                    if (!VM::valueToBool(cond))
-                        frame.ip += instr.operand;
+                auto cond = this->pop();
+                if (!VM::valueToBool(cond))
+                    frame.ip += instr.operand;
             } break;
             case OpCode::JMP_IF_TRUE: {
-                    auto cond = this->pop();
-                    if (VM::valueToBool(cond))
-                        frame.ip += instr.operand;
+                auto cond = this->pop();
+                if (VM::valueToBool(cond))
+                    frame.ip += instr.operand;
             } break;
             case OpCode::JMP: {
-                    frame.ip += instr.operand;
+                frame.ip += instr.operand;
             } break;
             default: break;
         }

--- a/src/LOICollectionA/frontend/ir/VM.h
+++ b/src/LOICollectionA/frontend/ir/VM.h
@@ -48,6 +48,12 @@ namespace LOICollection::frontend::ir {
         LOICOLLECTION_A_NDAPI static bool applyComparison(const ValueNode::ValueType& left, const ValueNode::ValueType& right, const std::string& op, DiagnosticEngine& diagnostics, const SourceLocation& loc = {});
 
     private:
+        struct FieldCacheSlot {
+            std::string name;
+            const FieldLayout* layout = nullptr;
+            int slot = -1;
+        };
+
         struct Frame {
             std::reference_wrapper<const BytecodeChunk> chunk;
 
@@ -81,8 +87,11 @@ namespace LOICollection::frontend::ir {
         std::unordered_map<int, NativeValueMethodCacheSlot> mNativeValueMethodSlots;
         std::unordered_map<int, NativeConstructorCacheSlot> mNativeConstructorSlots;
         std::unordered_map<int, FieldLayoutPtr> mClassLayouts;
+        std::unordered_map<const Instruction*, FieldCacheSlot> mFieldSlots;
 
         [[nodiscard]] const FieldLayoutPtr& classLayout(const BytecodeChunk& chunk, int classIndex);
+
+        [[nodiscard]] int resolveFieldSlot(Object& obj, const std::string& name, const Instruction& instr);
 
         ValueNode::ValueType execute(
             const std::shared_ptr<const BytecodeChunk>& owner,

--- a/src/LOICollectionA/frontend/ir/VM.h
+++ b/src/LOICollectionA/frontend/ir/VM.h
@@ -42,9 +42,12 @@ namespace LOICollection::frontend::ir {
 
         LOICOLLECTION_A_NDAPI static std::string valueToString(const ValueNode::ValueType& val);
         LOICOLLECTION_A_NDAPI static std::string typeNameOf(const ValueNode::ValueType& val);
+        LOICOLLECTION_A_NDAPI static ValueNode::ValueType applyArithmetic(const ValueNode::ValueType& left, const ValueNode::ValueType& right, OpCode op, DiagnosticEngine& diagnostics, const SourceLocation& loc = {});
         LOICOLLECTION_A_NDAPI static ValueNode::ValueType applyArithmetic(const ValueNode::ValueType& left, const ValueNode::ValueType& right, const std::string& op, DiagnosticEngine& diagnostics, const SourceLocation& loc = {});
+        LOICOLLECTION_A_NDAPI static ValueNode::ValueType applyUnary(const ValueNode::ValueType& operand, OpCode op, DiagnosticEngine& diagnostics, const SourceLocation& loc = {});
         LOICOLLECTION_A_NDAPI static ValueNode::ValueType applyUnary(const ValueNode::ValueType& operand, const std::string& op, DiagnosticEngine& diagnostics, const SourceLocation& loc = {});
         LOICOLLECTION_A_NDAPI static bool valueToBool(const ValueNode::ValueType& val);
+        LOICOLLECTION_A_NDAPI static bool applyComparison(const ValueNode::ValueType& left, const ValueNode::ValueType& right, OpCode op, DiagnosticEngine& diagnostics, const SourceLocation& loc = {});
         LOICOLLECTION_A_NDAPI static bool applyComparison(const ValueNode::ValueType& left, const ValueNode::ValueType& right, const std::string& op, DiagnosticEngine& diagnostics, const SourceLocation& loc = {});
 
     private:

--- a/src/LOICollectionA/frontend/ir/VM.h
+++ b/src/LOICollectionA/frontend/ir/VM.h
@@ -102,6 +102,7 @@ namespace LOICollection::frontend::ir {
         );
 
         void push(const ValueNode::ValueType& v);
+        void push(ValueNode::ValueType&& v);
         ValueNode::ValueType pop();
 
         void storeVariable(

--- a/src/LOICollectionA/frontend/ir/VM.h
+++ b/src/LOICollectionA/frontend/ir/VM.h
@@ -61,7 +61,8 @@ namespace LOICollection::frontend::ir {
             std::reference_wrapper<const BytecodeChunk> chunk;
 
             size_t ip = 0;
-            std::vector<ValueNode::ValueType> locals;
+            size_t localsBase = 0;
+            size_t localsSize = 0;
 
             ValueNode::ValueType thisObj;
             bool hasThis = false;
@@ -70,7 +71,7 @@ namespace LOICollection::frontend::ir {
             bool hasPending = false;
 
             explicit Frame(const BytecodeChunk& chunkRef)
-                : chunk(chunkRef), locals(chunkRef.slotCount) {}
+                : chunk(chunkRef), localsSize(chunkRef.slotCount) {}
         };
 
         DiagnosticEngine& diagnostics;
@@ -81,6 +82,7 @@ namespace LOICollection::frontend::ir {
 
         std::vector<Frame> frames;
         std::vector<ValueNode::ValueType> stack;
+        std::vector<ValueNode::ValueType> localPool;
 
         std::shared_ptr<GlobalsTable> globals;
 

--- a/src/LOICollectionA/frontend/ir/compiler/ForIn.cpp
+++ b/src/LOICollectionA/frontend/ir/compiler/ForIn.cpp
@@ -81,7 +81,7 @@ namespace LOICollection::frontend::ir {
 
         this->current.get().emit(OpCode::LOAD_SLOT, idxSlot, node.loc);
         this->emitIterableLength(protocol, seqSlot, node.loc);
-        this->current.get().emit(OpCode::CMP_LT, 0, node.loc);
+        this->current.get().emit(OpCode::CMP_LT_I, 0, node.loc);
 
         size_t jmpFalseIdx = this->current.get().emit(OpCode::JMP_IF_FALSE, 0, node.loc);
 
@@ -99,7 +99,7 @@ namespace LOICollection::frontend::ir {
         int oneIdx = this->addConstant(1);
         this->current.get().emit(OpCode::LOAD_SLOT, idxSlot, node.loc);
         this->current.get().emit(OpCode::PUSH_INT, oneIdx, node.loc);
-        this->current.get().emit(OpCode::ADD, 0, node.loc);
+        this->current.get().emit(OpCode::ADD_I, 0, node.loc);
         this->current.get().emit(OpCode::STORE_SLOT, idxSlot, node.loc);
 
         node.body->accept(*this);

--- a/src/LOICollectionA/frontend/ir/compiler/ForIn.cpp
+++ b/src/LOICollectionA/frontend/ir/compiler/ForIn.cpp
@@ -50,8 +50,8 @@ namespace LOICollection::frontend::ir {
                 return;
             }
 
-            this->current.get().emit(OpCode::LOAD_SLOT, seqSlot, loc);
             this->current.get().emit(OpCode::LOAD_SLOT, idxSlot, loc);
+            this->current.get().emit(OpCode::LOAD_SLOT, seqSlot, loc);
 
             int metaIdx = this->addByNameCall(std::string(elementMethod), 1);
             this->current.get().emit(OpCode::CALL_METHOD_BY_NAME, metaIdx, loc);

--- a/src/LOICollectionA/frontend/ir/opt/analysis/ControlFlowGraph.cpp
+++ b/src/LOICollectionA/frontend/ir/opt/analysis/ControlFlowGraph.cpp
@@ -1,0 +1,111 @@
+#include <algorithm>
+
+#include "LOICollectionA/frontend/ir/opt/analysis/OpTraits.h"
+
+#include "LOICollectionA/frontend/ir/opt/analysis/ControlFlowGraph.h"
+
+namespace LOICollection::frontend::ir::opt {
+namespace {
+    int jumpTarget(const Instruction& instr, int at) {
+        return at + 1 + instr.operand;
+    }
+}
+
+    std::vector<int> ControlFlowGraph::leaders(const std::vector<Instruction>& code) {
+        const int size = static_cast<int>(code.size());
+
+        std::vector<bool> isLeader(size + 1, false);
+        isLeader[0] = true;
+
+        for (int i = 0; i < size; ++i) {
+            if (isJump(code[i].op)) {
+                const int target = jumpTarget(code[i], i);
+
+                if (target >= 0 && target <= size)
+                    isLeader[target] = true;
+
+                isLeader[i + 1] = true;
+            }
+
+            if (isTerminator(code[i].op))
+                isLeader[i + 1] = true;
+        }
+
+        std::vector<int> out;
+        for (int i = 0; i <= size; ++i)
+            if (isLeader[i])
+                out.push_back(i);
+
+        return out;
+    }
+
+    ControlFlowGraph::ControlFlowGraph(const std::vector<Instruction>& code) {
+        mBlockOfIndex.assign(code.size() + 1, 0);
+
+        const std::vector<int> starts = leaders(code);
+
+        for (size_t k = 0; k < starts.size(); ++k) {
+            Block block;
+            block.begin = starts[k];
+            block.end = k + 1 < starts.size() ? starts[k + 1] : static_cast<int>(code.size());
+
+            mBlocks.push_back(std::move(block));
+        }
+
+        for (size_t b = 0; b < mBlocks.size(); ++b)
+            for (int i = mBlocks[b].begin; i < mBlocks[b].end; ++i)
+                mBlockOfIndex[i] = static_cast<int>(b);
+
+        if (!code.empty())
+            mBlockOfIndex[code.size()] = static_cast<int>(mBlocks.size()) - 1;
+
+        this->link(code);
+    }
+
+    int ControlFlowGraph::blockOf(int index) const {
+        if (index < 0 || index >= static_cast<int>(mBlockOfIndex.size()))
+            return -1;
+
+        return mBlockOfIndex[index];
+    }
+
+    void ControlFlowGraph::link(const std::vector<Instruction>& code) {
+        for (size_t b = 0; b < mBlocks.size(); ++b) {
+            Block& block = mBlocks[b];
+
+            if (block.begin >= block.end)
+                continue;
+
+            const int last = block.end - 1;
+            const Instruction& term = code[last];
+
+            auto addEdge = [&](int target) {
+                const int successor = this->blockOf(target);
+
+                if (successor < 0 || successor == static_cast<int>(b))
+                    return;
+
+                if (std::ranges::find(block.successors, successor) == block.successors.end())
+                    block.successors.push_back(successor);
+            };
+
+            if (isJump(term.op)) {
+                const int target = jumpTarget(term, last);
+
+                if (target >= 0 && target <= static_cast<int>(code.size()))
+                    addEdge(target);
+                else
+                    addEdge(last + 1);
+
+                if (term.op != OpCode::JMP)
+                    addEdge(last + 1);
+            } else if (!isTerminator(term.op)) {
+                addEdge(last + 1);
+            }
+        }
+
+        for (size_t b = 0; b < mBlocks.size(); ++b)
+            for (const int successor : mBlocks[b].successors)
+                mBlocks[successor].predecessors.push_back(static_cast<int>(b));
+    }
+}

--- a/src/LOICollectionA/frontend/ir/opt/analysis/ControlFlowGraph.cpp
+++ b/src/LOICollectionA/frontend/ir/opt/analysis/ControlFlowGraph.cpp
@@ -9,7 +9,7 @@ namespace LOICollection::frontend::ir::opt {
         int jumpTarget(const Instruction& instr, int at) {
             return at + 1 + instr.operand;
         }
-}
+    }
 
     std::vector<int> ControlFlowGraph::leaders(const std::vector<Instruction>& code) {
         const int size = static_cast<int>(code.size());

--- a/src/LOICollectionA/frontend/ir/opt/analysis/ControlFlowGraph.cpp
+++ b/src/LOICollectionA/frontend/ir/opt/analysis/ControlFlowGraph.cpp
@@ -5,10 +5,10 @@
 #include "LOICollectionA/frontend/ir/opt/analysis/ControlFlowGraph.h"
 
 namespace LOICollection::frontend::ir::opt {
-namespace {
-    int jumpTarget(const Instruction& instr, int at) {
-        return at + 1 + instr.operand;
-    }
+    namespace {
+        int jumpTarget(const Instruction& instr, int at) {
+            return at + 1 + instr.operand;
+        }
 }
 
     std::vector<int> ControlFlowGraph::leaders(const std::vector<Instruction>& code) {

--- a/src/LOICollectionA/frontend/ir/opt/analysis/ControlFlowGraph.h
+++ b/src/LOICollectionA/frontend/ir/opt/analysis/ControlFlowGraph.h
@@ -1,0 +1,33 @@
+#pragma once
+
+#include <vector>
+
+#include "LOICollectionA/frontend/ir/ByteCode.h"
+
+namespace LOICollection::frontend::ir::opt {
+    class ControlFlowGraph {
+    public:
+        struct Block {
+            int begin = 0;
+            int end = 0;
+            std::vector<int> successors;
+            std::vector<int> predecessors;
+        };
+
+        explicit ControlFlowGraph(const std::vector<Instruction>& code);
+
+        const std::vector<Block>& blocks() const { return mBlocks; }
+
+        int blockOf(int index) const;
+
+        int size() const { return static_cast<int>(mBlocks.size()); }
+
+    private:
+        static std::vector<int> leaders(const std::vector<Instruction>& code);
+
+        void link(const std::vector<Instruction>& code);
+
+        std::vector<Block> mBlocks;
+        std::vector<int> mBlockOfIndex;
+    };
+}

--- a/src/LOICollectionA/frontend/ir/opt/analysis/FoldPredicates.cpp
+++ b/src/LOICollectionA/frontend/ir/opt/analysis/FoldPredicates.cpp
@@ -16,10 +16,6 @@ namespace LOICollection::frontend::ir::opt {
         return std::monostate{};
     }
 
-    // ValueType holds non-comparable alternatives, so scalar equality is checked per kind.
-    // Floats compare bitwise-sign aware: `+0.0 == -0.0` under IEEE754, but they are
-    // observably different values (`to_string` and `1/x` disagree), so pool dedup must
-    // never conflate them.
     bool sameScalar(const ValueNode::ValueType& a, const ValueNode::ValueType& b) {
         if (a.index() != b.index() || !isScalarValue(a))
             return false;
@@ -37,9 +33,6 @@ namespace LOICollection::frontend::ir::opt {
         }
     }
 
-    // `kept op identity == kept`, applicable when the kept operand is a known number of a
-    // compatible kind. Divided by type-promotion rules: `x / 1` and `x ^ 1` always produce
-    // floats, and float `x + 0.0` flips -0.0, so those combinations stay untouched.
     bool identityEligible(OpCode op, const StackEntry& kept, const StackEntry& identity) {
         if (!isKnown(kept) || !isKnown(identity) || !knownValue(identity).removable)
             return false;
@@ -54,11 +47,11 @@ namespace LOICollection::frontend::ir::opt {
         bool identityFloatOne = std::holds_alternative<float>(identityValue) && std::get<float>(identityValue) == 1.0f;
 
         switch (op) {
-            case OpCode::ADD: // x + 0 / 0 + x
+            case OpCode::ADD: 
                 return keptIsInt && identityIntZero;
-            case OpCode::SUB: // x - 0
+            case OpCode::SUB: 
                 return keptIsInt && identityIntZero;
-            case OpCode::MUL: // x * 1 / 1 * x
+            case OpCode::MUL: 
                 return (keptIsInt && identityIntOne) || (keptIsFloat && (identityIntOne || identityFloatOne));
             case OpCode::ADD_I:
                 return keptIsInt && identityIntZero;
@@ -66,9 +59,9 @@ namespace LOICollection::frontend::ir::opt {
                 return keptIsInt && identityIntZero;
             case OpCode::MUL_I:
                 return keptIsInt && identityIntOne;
-            case OpCode::DIV: // x / 1
+            case OpCode::DIV: 
                 return keptIsFloat && (identityIntOne || identityFloatOne);
-            case OpCode::POW: // x ^ 1
+            case OpCode::POW: 
                 return keptIsFloat && (identityIntOne || identityFloatOne);
             default:
                 return false;

--- a/src/LOICollectionA/frontend/ir/opt/analysis/FoldPredicates.cpp
+++ b/src/LOICollectionA/frontend/ir/opt/analysis/FoldPredicates.cpp
@@ -60,6 +60,12 @@ namespace LOICollection::frontend::ir::opt {
                 return keptIsInt && identityIntZero;
             case OpCode::MUL: // x * 1 / 1 * x
                 return (keptIsInt && identityIntOne) || (keptIsFloat && (identityIntOne || identityFloatOne));
+            case OpCode::ADD_I:
+                return keptIsInt && identityIntZero;
+            case OpCode::SUB_I:
+                return keptIsInt && identityIntZero;
+            case OpCode::MUL_I:
+                return keptIsInt && identityIntOne;
             case OpCode::DIV: // x / 1
                 return keptIsFloat && (identityIntOne || identityFloatOne);
             case OpCode::POW: // x ^ 1

--- a/src/LOICollectionA/frontend/ir/opt/analysis/LoopAnalysis.cpp
+++ b/src/LOICollectionA/frontend/ir/opt/analysis/LoopAnalysis.cpp
@@ -5,32 +5,32 @@
 #include "LOICollectionA/frontend/ir/opt/analysis/LoopAnalysis.h"
 
 namespace LOICollection::frontend::ir::opt {
-namespace {
-    void depthFirstSearch(
-        int block,
-        const ControlFlowGraph& cfg,
-        std::vector<int>& state,
-        std::vector<std::pair<int, int>>& backEdges
-    ) {
-        state[block] = 1;
+    namespace {
+        void depthFirstSearch(
+            int block,
+            const ControlFlowGraph& cfg,
+            std::vector<int>& state,
+            std::vector<std::pair<int, int>>& backEdges
+        ) {
+            state[block] = 1;
 
-        for (const int successor : cfg.blocks()[block].successors) {
-            if (successor < 0 || successor >= cfg.size())
-                continue;
+            for (const int successor : cfg.blocks()[block].successors) {
+                if (successor < 0 || successor >= cfg.size())
+                    continue;
 
-            if (state[successor] == 1)
-                backEdges.emplace_back(block, successor);
-            else if (state[successor] == 0)
-                depthFirstSearch(successor, cfg, state, backEdges);
+                if (state[successor] == 1)
+                    backEdges.emplace_back(block, successor);
+                else if (state[successor] == 0)
+                    depthFirstSearch(successor, cfg, state, backEdges);
+            }
+
+            state[block] = 2;
         }
 
-        state[block] = 2;
-    }
-
-    void append(std::vector<int>& into, int value) {
-        if (std::ranges::find(into, value) == into.end())
-            into.push_back(value);
-    }
+        void append(std::vector<int>& into, int value) {
+            if (std::ranges::find(into, value) == into.end())
+                into.push_back(value);
+        }
 }
 
     bool NaturalLoop::contains(int block) const {

--- a/src/LOICollectionA/frontend/ir/opt/analysis/LoopAnalysis.cpp
+++ b/src/LOICollectionA/frontend/ir/opt/analysis/LoopAnalysis.cpp
@@ -1,0 +1,90 @@
+#include <algorithm>
+#include <map>
+#include <utility>
+
+#include "LOICollectionA/frontend/ir/opt/analysis/LoopAnalysis.h"
+
+namespace LOICollection::frontend::ir::opt {
+namespace {
+    void depthFirstSearch(
+        int block,
+        const ControlFlowGraph& cfg,
+        std::vector<int>& state,
+        std::vector<std::pair<int, int>>& backEdges
+    ) {
+        state[block] = 1;
+
+        for (const int successor : cfg.blocks()[block].successors) {
+            if (successor < 0 || successor >= cfg.size())
+                continue;
+
+            if (state[successor] == 1)
+                backEdges.emplace_back(block, successor);
+            else if (state[successor] == 0)
+                depthFirstSearch(successor, cfg, state, backEdges);
+        }
+
+        state[block] = 2;
+    }
+
+    void append(std::vector<int>& into, int value) {
+        if (std::ranges::find(into, value) == into.end())
+            into.push_back(value);
+    }
+}
+
+    bool NaturalLoop::contains(int block) const {
+        return std::ranges::find(blocks, block) != blocks.end();
+    }
+
+    std::vector<NaturalLoop> findNaturalLoops(const ControlFlowGraph& cfg) {
+        std::vector<std::pair<int, int>> backEdges;
+        std::vector<int> state(cfg.size(), 0);
+
+        for (int block = 0; block < cfg.size(); ++block)
+            if (state[block] == 0)
+                depthFirstSearch(block, cfg, state, backEdges);
+
+        std::map<int, NaturalLoop> loops;
+
+        for (const auto& [tail, header] : backEdges) {
+            NaturalLoop& loop = loops[header];
+            loop.header = header;
+
+            if (loop.blocks.empty())
+                loop.blocks.push_back(header);
+
+            std::vector<int> pending{ tail };
+            while (!pending.empty()) {
+                const int block = pending.back();
+                pending.pop_back();
+
+                if (loop.contains(block))
+                    continue;
+
+                loop.blocks.push_back(block);
+
+                for (const int predecessor : cfg.blocks()[block].predecessors)
+                    pending.push_back(predecessor);
+            }
+        }
+
+        std::vector<NaturalLoop> out;
+        for (auto& [header, loop] : loops) {
+            std::ranges::sort(loop.blocks);
+
+            for (const int block : loop.blocks)
+                for (const int successor : cfg.blocks()[block].successors)
+                    if (!loop.contains(successor))
+                        append(loop.exits, successor);
+
+            for (const int predecessor : cfg.blocks()[header].predecessors)
+                if (!loop.contains(predecessor))
+                    append(loop.entries, predecessor);
+
+            out.push_back(std::move(loop));
+        }
+
+        return out;
+    }
+}

--- a/src/LOICollectionA/frontend/ir/opt/analysis/LoopAnalysis.cpp
+++ b/src/LOICollectionA/frontend/ir/opt/analysis/LoopAnalysis.cpp
@@ -31,7 +31,7 @@ namespace LOICollection::frontend::ir::opt {
             if (std::ranges::find(into, value) == into.end())
                 into.push_back(value);
         }
-}
+    }
 
     bool NaturalLoop::contains(int block) const {
         return std::ranges::find(blocks, block) != blocks.end();

--- a/src/LOICollectionA/frontend/ir/opt/analysis/LoopAnalysis.h
+++ b/src/LOICollectionA/frontend/ir/opt/analysis/LoopAnalysis.h
@@ -1,0 +1,18 @@
+#pragma once
+
+#include <vector>
+
+#include "LOICollectionA/frontend/ir/opt/analysis/ControlFlowGraph.h"
+
+namespace LOICollection::frontend::ir::opt {
+    struct NaturalLoop {
+        int header = -1;
+        std::vector<int> blocks;
+        std::vector<int> exits;
+        std::vector<int> entries;
+
+        bool contains(int block) const;
+    };
+
+    std::vector<NaturalLoop> findNaturalLoops(const ControlFlowGraph& cfg);
+}

--- a/src/LOICollectionA/frontend/ir/opt/analysis/OpTraits.cpp
+++ b/src/LOICollectionA/frontend/ir/opt/analysis/OpTraits.cpp
@@ -1,4 +1,0 @@
-#include "LOICollectionA/frontend/ir/opt/analysis/OpTraits.h"
-
-namespace LOICollection::frontend::ir::opt {
-}

--- a/src/LOICollectionA/frontend/ir/opt/analysis/OpTraits.cpp
+++ b/src/LOICollectionA/frontend/ir/opt/analysis/OpTraits.cpp
@@ -1,27 +1,4 @@
 #include "LOICollectionA/frontend/ir/opt/analysis/OpTraits.h"
 
 namespace LOICollection::frontend::ir::opt {
-    std::string arithmeticOpName(OpCode op) {
-        switch (op) {
-            case OpCode::ADD: return "+";
-            case OpCode::SUB: return "-";
-            case OpCode::MUL: return "*";
-            case OpCode::DIV: return "/";
-            case OpCode::MOD: return "%";
-            case OpCode::POW: return "^";
-            default: return "";
-        }
-    }
-
-    std::string comparisonOpName(OpCode op) {
-        switch (op) {
-            case OpCode::CMP_EQ: return "==";
-            case OpCode::CMP_NE: return "!=";
-            case OpCode::CMP_GT: return ">";
-            case OpCode::CMP_LT: return "<";
-            case OpCode::CMP_GE: return ">=";
-            case OpCode::CMP_LE: return "<=";
-            default: return "";
-        }
-    }
 }

--- a/src/LOICollectionA/frontend/ir/opt/analysis/OpTraits.h
+++ b/src/LOICollectionA/frontend/ir/opt/analysis/OpTraits.h
@@ -35,7 +35,4 @@ namespace LOICollection::frontend::ir::opt {
                 return false;
         }
     }
-
-    std::string arithmeticOpName(OpCode op);
-    std::string comparisonOpName(OpCode op);
 }

--- a/src/LOICollectionA/frontend/ir/opt/analysis/OpTraits.h
+++ b/src/LOICollectionA/frontend/ir/opt/analysis/OpTraits.h
@@ -17,8 +17,6 @@ namespace LOICollection::frontend::ir::opt {
         return op == OpCode::STORE_VAR || op == OpCode::STORE_SLOT;
     }
 
-    // Opcodes that may execute script code (function bodies, lambdas, constructors) or
-    // create object fields; any of these can rebind what a later LOAD_VAR resolves to.
     inline bool canWriteVariables(OpCode op) {
         switch (op) {
             case OpCode::CALL:

--- a/src/LOICollectionA/frontend/ir/opt/analysis/OpTraits.h
+++ b/src/LOICollectionA/frontend/ir/opt/analysis/OpTraits.h
@@ -25,7 +25,9 @@ namespace LOICollection::frontend::ir::opt {
             case OpCode::CALL_MACRO:
             case OpCode::CALL_METHOD:
             case OpCode::CALL_METHOD_VIRTUAL:
+            case OpCode::CALL_METHOD_BY_NAME:
             case OpCode::CALL_FUNC:
+            case OpCode::CALL_NATIVE_METHOD:
             case OpCode::CALL_LAMBDA:
             case OpCode::CALL_SUPER_CTOR:
             case OpCode::NEW:

--- a/src/LOICollectionA/frontend/ir/opt/analysis/StackEffect.cpp
+++ b/src/LOICollectionA/frontend/ir/opt/analysis/StackEffect.cpp
@@ -1,0 +1,95 @@
+#include "LOICollectionA/frontend/ir/opt/analysis/OpTraits.h"
+
+#include "LOICollectionA/frontend/ir/opt/analysis/StackEffect.h"
+
+namespace LOICollection::frontend::ir::opt {
+    bool stackEffectOf(const Instruction& instr, const BytecodeChunk& chunk, StackEffect& out) {
+        out = {};
+
+        switch (instr.op) {
+            case OpCode::PUSH_INT:
+            case OpCode::PUSH_FLOAT:
+            case OpCode::PUSH_STR:
+            case OpCode::PUSH_BOOL:
+            case OpCode::PUSH_NONE:
+            case OpCode::LOAD_SLOT:
+            case OpCode::LOAD_VAR:
+            case OpCode::LOAD_THIS:
+            case OpCode::MAKE_LAMBDA:
+                out.pushes = 1;
+                return true;
+
+            case OpCode::POP:
+            case OpCode::STORE_SLOT:
+            case OpCode::STORE_VAR:
+                out.pops = 1;
+                return true;
+
+            case OpCode::DUP:
+            case OpCode::DUP_IS_NONE:
+                out.pushes = 1;
+                out.peeks = 1;
+                return true;
+
+            case OpCode::DUP2:
+                out.pushes = 2;
+                out.peeks = 2;
+                return true;
+
+            case OpCode::DUP_STORE:
+            case OpCode::DUP_STORE_SLOT:
+                out.peeks = 1;
+                return true;
+
+            case OpCode::ROT3:
+                out.pops = 3;
+                out.pushes = 3;
+                return true;
+
+            case OpCode::SWAP2:
+                out.pops = 4;
+                out.pushes = 4;
+                return true;
+
+            case OpCode::UNWRAP:
+            case OpCode::TYPE_OF:
+            case OpCode::HAS_VALUE:
+            case OpCode::IS_NONE:
+            case OpCode::NEG:
+            case OpCode::NOT:
+                out.pops = 1;
+                out.pushes = 1;
+                return true;
+
+            case OpCode::ADD:
+            case OpCode::SUB:
+            case OpCode::MUL:
+            case OpCode::DIV:
+            case OpCode::MOD:
+            case OpCode::POW:
+            case OpCode::CMP_EQ:
+            case OpCode::CMP_NE:
+            case OpCode::CMP_GT:
+            case OpCode::CMP_LT:
+            case OpCode::CMP_GE:
+            case OpCode::CMP_LE:
+            case OpCode::LOGIC_AND:
+            case OpCode::LOGIC_OR:
+                out.pops = 2;
+                out.pushes = 1;
+                return true;
+
+            case OpCode::JMP_IF_FALSE:
+            case OpCode::JMP_IF_TRUE:
+                out.pops = 1;
+                return true;
+
+            case OpCode::JMP:
+            case OpCode::HALT:
+                return true;
+
+            default:
+                return false;
+        }
+    }
+}

--- a/src/LOICollectionA/frontend/ir/opt/analysis/StackEffect.cpp
+++ b/src/LOICollectionA/frontend/ir/opt/analysis/StackEffect.cpp
@@ -56,6 +56,7 @@ namespace LOICollection::frontend::ir::opt {
             case OpCode::HAS_VALUE:
             case OpCode::IS_NONE:
             case OpCode::NEG:
+            case OpCode::NEG_I:
             case OpCode::NOT:
                 out.pops = 1;
                 out.pushes = 1;
@@ -73,6 +74,16 @@ namespace LOICollection::frontend::ir::opt {
             case OpCode::CMP_LT:
             case OpCode::CMP_GE:
             case OpCode::CMP_LE:
+            case OpCode::ADD_I:
+            case OpCode::SUB_I:
+            case OpCode::MUL_I:
+            case OpCode::MOD_I:
+            case OpCode::CMP_EQ_I:
+            case OpCode::CMP_NE_I:
+            case OpCode::CMP_GT_I:
+            case OpCode::CMP_LT_I:
+            case OpCode::CMP_GE_I:
+            case OpCode::CMP_LE_I:
             case OpCode::LOGIC_AND:
             case OpCode::LOGIC_OR:
                 out.pops = 2;

--- a/src/LOICollectionA/frontend/ir/opt/analysis/StackEffect.h
+++ b/src/LOICollectionA/frontend/ir/opt/analysis/StackEffect.h
@@ -1,0 +1,17 @@
+#pragma once
+
+#include "LOICollectionA/frontend/ir/ByteCode.h"
+
+namespace LOICollection::frontend::ir::opt {
+    struct StackEffect {
+        int pops = 0;
+        int pushes = 0;
+        int peeks = 0;
+
+        int net() const { return pushes - pops; }
+
+        int reach() const { return pops + peeks; }
+    };
+
+    bool stackEffectOf(const Instruction& instr, const BytecodeChunk& chunk, StackEffect& out);
+}

--- a/src/LOICollectionA/frontend/ir/opt/passes/CSEPass.cpp
+++ b/src/LOICollectionA/frontend/ir/opt/passes/CSEPass.cpp
@@ -146,12 +146,13 @@ namespace LOICollection::frontend::ir::opt {
                 int redirect = -1;
 
                 for (size_t e = 0; e < edits.size(); ++e) {
-                    if (edits[e].at == pos)
+                    if (edits[e].at == pos) {
                         for (const Instruction& ins : edits[e].insert) {
                             placed[e].push_back(static_cast<int>(rewritten.size()));
                             rewritten.push_back(ins);
                             origin.push_back(-1);
                         }
+                    }
 
                     if (pos >= edits[e].at && pos < edits[e].eraseTo) {
                         erased = true;

--- a/src/LOICollectionA/frontend/ir/opt/passes/CSEPass.cpp
+++ b/src/LOICollectionA/frontend/ir/opt/passes/CSEPass.cpp
@@ -128,41 +128,70 @@ namespace LOICollection::frontend::ir::opt {
             }
         }
 
+        // Rewrites the code and, because jumps here are relative, re-resolves every
+        // one of them: an insertion or an erasure shifts the distance between a jump
+        // and its target. Jumps that aimed at an erased operand now aim at the reload
+        // that replaced it.
         void apply(std::vector<Instruction>& code, std::vector<CSEPass::Edit>& edits) {
             std::sort(edits.begin(), edits.end(),
                 [](const CSEPass::Edit& a, const CSEPass::Edit& b) { return a.at < b.at; });
 
+            const int n = static_cast<int>(code.size());
+
             std::vector<Instruction> rewritten;
             rewritten.reserve(code.size());
 
-            const int n = static_cast<int>(code.size());
-            size_t ei = 0;
+            std::vector<int> oldToNew(n, -1);
+            std::vector<int> origin;
+            std::vector<std::vector<int>> placed(edits.size());
 
             for (int pos = 0; pos <= n; ++pos) {
-                while (ei < edits.size() && edits[ei].at == pos) {
-                    for (const Instruction& ins : edits[ei].insert)
-                        rewritten.push_back(ins);
-                    ++ei;
+                bool erased = false;
+                int redirect = -1;
+
+                for (size_t e = 0; e < edits.size(); ++e) {
+                    if (edits[e].at == pos)
+                        for (const Instruction& ins : edits[e].insert) {
+                            placed[e].push_back(static_cast<int>(rewritten.size()));
+                            rewritten.push_back(ins);
+                            origin.push_back(-1);
+                        }
+
+                    if (pos >= edits[e].at && pos < edits[e].eraseTo) {
+                        erased = true;
+                        if (!placed[e].empty())
+                            redirect = placed[e].front();
+                    }
                 }
 
                 if (pos == n)
                     break;
 
-                bool erased = false;
-                for (const CSEPass::Edit& e : edits)
-                    if (e.at <= pos && pos < e.eraseTo) {
-                        erased = true;
-                        break;
-                    }
+                if (erased) {
+                    if (redirect >= 0)
+                        oldToNew[pos] = redirect;
+                    continue;
+                }
 
-                if (!erased)
-                    rewritten.push_back(code[pos]);
+                oldToNew[pos] = static_cast<int>(rewritten.size());
+                origin.push_back(pos);
+                rewritten.push_back(code[pos]);
             }
 
-            while (ei < edits.size()) {
-                for (const Instruction& ins : edits[ei].insert)
-                    rewritten.push_back(ins);
-                ++ei;
+            for (size_t k = 0; k < rewritten.size(); ++k) {
+                if (origin[k] < 0 || !isJump(rewritten[k].op))
+                    continue;
+
+                const int oldTarget = origin[k] + 1 + rewritten[k].operand;
+
+                int newTarget = static_cast<int>(rewritten.size());
+                if (oldTarget >= 0 && oldTarget < n) {
+                    newTarget = oldToNew[oldTarget];
+                    for (int j = oldTarget; j < n && newTarget < 0; ++j)
+                        newTarget = oldToNew[j];
+                }
+
+                rewritten[k].operand = newTarget - static_cast<int>(k) - 1;
             }
 
             code = std::move(rewritten);
@@ -265,10 +294,14 @@ namespace LOICollection::frontend::ir::opt {
                     rs.insert(rs.end(), right.readSlots.begin(), right.readSlots.end());
                     const int curStart = std::min(left.start, right.start);
 
+                    // Every instruction is emitted even when it is about to be erased:
+                    // keeping `out` index-aligned with the input is what lets jumps,
+                    // whose offsets are relative, be re-resolved in `apply`.
                     auto it = avail.find(key);
                     if (it != avail.end() && it->second.spilled && left.atom && right.atom) {
-                        edits.push_back({ curStart, static_cast<int>(out.size()),
+                        edits.push_back({ curStart, static_cast<int>(out.size()) + 1,
                             { Instruction{ OpCode::LOAD_SLOT, it->second.slot, loc } } });
+                        out.push_back(ins);
                         ++eliminated;
                         vstack.push_back(Val{ key, curStart, rs, true });
                     } else {
@@ -278,8 +311,9 @@ namespace LOICollection::frontend::ir::opt {
                             it->second.spilled = true;
                             edits.push_back({ it->second.firstOpPos + 1, -1,
                                 { Instruction{ OpCode::DUP_STORE_SLOT, s, mChunk.code[it->second.firstOpPos].loc } } });
-                            edits.push_back({ curStart, static_cast<int>(out.size()),
+                            edits.push_back({ curStart, static_cast<int>(out.size()) + 1,
                                 { Instruction{ OpCode::LOAD_SLOT, s, loc } } });
+                            out.push_back(ins);
                             ++eliminated;
                             vstack.push_back(Val{ key, curStart, rs, true });
                         } else {
@@ -306,8 +340,9 @@ namespace LOICollection::frontend::ir::opt {
 
                     auto it = avail.find(key);
                     if (it != avail.end() && it->second.spilled && arg.atom) {
-                        edits.push_back({ curStart, static_cast<int>(out.size()),
+                        edits.push_back({ curStart, static_cast<int>(out.size()) + 1,
                             { Instruction{ OpCode::LOAD_SLOT, it->second.slot, loc } } });
+                        out.push_back(ins);
                         ++eliminated;
                         vstack.push_back(Val{ key, curStart, arg.readSlots, true });
                     } else if (it != avail.end() && arg.atom) {
@@ -316,8 +351,9 @@ namespace LOICollection::frontend::ir::opt {
                         it->second.spilled = true;
                         edits.push_back({ it->second.firstOpPos + 1, -1,
                             { Instruction{ OpCode::DUP_STORE_SLOT, s, mChunk.code[it->second.firstOpPos].loc } } });
-                        edits.push_back({ curStart, static_cast<int>(out.size()),
+                        edits.push_back({ curStart, static_cast<int>(out.size()) + 1,
                             { Instruction{ OpCode::LOAD_SLOT, s, loc } } });
+                        out.push_back(ins);
                         ++eliminated;
                         vstack.push_back(Val{ key, curStart, arg.readSlots, true });
                     } else {

--- a/src/LOICollectionA/frontend/ir/opt/passes/CSEPass.cpp
+++ b/src/LOICollectionA/frontend/ir/opt/passes/CSEPass.cpp
@@ -128,10 +128,6 @@ namespace LOICollection::frontend::ir::opt {
             }
         }
 
-        // Rewrites the code and, because jumps here are relative, re-resolves every
-        // one of them: an insertion or an erasure shifts the distance between a jump
-        // and its target. Jumps that aimed at an erased operand now aim at the reload
-        // that replaced it.
         void apply(std::vector<Instruction>& code, std::vector<CSEPass::Edit>& edits) {
             std::sort(edits.begin(), edits.end(),
                 [](const CSEPass::Edit& a, const CSEPass::Edit& b) { return a.at < b.at; });
@@ -294,9 +290,6 @@ namespace LOICollection::frontend::ir::opt {
                     rs.insert(rs.end(), right.readSlots.begin(), right.readSlots.end());
                     const int curStart = std::min(left.start, right.start);
 
-                    // Every instruction is emitted even when it is about to be erased:
-                    // keeping `out` index-aligned with the input is what lets jumps,
-                    // whose offsets are relative, be re-resolved in `apply`.
                     auto it = avail.find(key);
                     if (it != avail.end() && it->second.spilled && left.atom && right.atom) {
                         edits.push_back({ curStart, static_cast<int>(out.size()) + 1,

--- a/src/LOICollectionA/frontend/ir/opt/passes/CSEPass.cpp
+++ b/src/LOICollectionA/frontend/ir/opt/passes/CSEPass.cpp
@@ -46,6 +46,16 @@ namespace LOICollection::frontend::ir::opt {
                 case OpCode::CMP_LT:
                 case OpCode::CMP_GE:
                 case OpCode::CMP_LE:
+                case OpCode::ADD_I:
+                case OpCode::SUB_I:
+                case OpCode::MUL_I:
+                case OpCode::MOD_I:
+                case OpCode::CMP_EQ_I:
+                case OpCode::CMP_NE_I:
+                case OpCode::CMP_GT_I:
+                case OpCode::CMP_LT_I:
+                case OpCode::CMP_GE_I:
+                case OpCode::CMP_LE_I:
                     return true;
                 default:
                     return false;
@@ -55,6 +65,7 @@ namespace LOICollection::frontend::ir::opt {
         bool isPureUnary(OpCode op) {
             switch (op) {
                 case OpCode::NEG:
+                case OpCode::NEG_I:
                 case OpCode::NOT:
                 case OpCode::INSTANCEOF:
                 case OpCode::LOAD_LEN:
@@ -81,19 +92,6 @@ namespace LOICollection::frontend::ir::opt {
             }
         }
 
-        bool isStackReset(OpCode op) {
-            switch (op) {
-                case OpCode::ROT3:
-                case OpCode::SWAP2:
-                case OpCode::DUP2:
-                case OpCode::UNWRAP:
-                case OpCode::BIND_THIS:
-                    return true;
-                default:
-                    return false;
-            }
-        }
-
         std::string opName(OpCode op) {
             switch (op) {
                 case OpCode::ADD: return "ADD";
@@ -110,6 +108,17 @@ namespace LOICollection::frontend::ir::opt {
                 case OpCode::CMP_LE: return "LE";
                 case OpCode::NEG: return "NEG";
                 case OpCode::NOT: return "NOT";
+                case OpCode::ADD_I: return "ADDI";
+                case OpCode::SUB_I: return "SUBI";
+                case OpCode::MUL_I: return "MULI";
+                case OpCode::MOD_I: return "MODI";
+                case OpCode::CMP_EQ_I: return "EQI";
+                case OpCode::CMP_NE_I: return "NEI";
+                case OpCode::CMP_GT_I: return "GTI";
+                case OpCode::CMP_LT_I: return "LTI";
+                case OpCode::CMP_GE_I: return "GEI";
+                case OpCode::CMP_LE_I: return "LEI";
+                case OpCode::NEG_I: return "NEGI";
                 case OpCode::INSTANCEOF: return "INST";
                 case OpCode::LOAD_LEN: return "LEN";
                 case OpCode::DUP_IS_NONE: return "ISNONE";

--- a/src/LOICollectionA/frontend/ir/opt/passes/CSEPass.cpp
+++ b/src/LOICollectionA/frontend/ir/opt/passes/CSEPass.cpp
@@ -1,0 +1,345 @@
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+#include "LOICollectionA/frontend/ir/opt/analysis/OpTraits.h"
+#include "LOICollectionA/frontend/ir/opt/analysis/ControlFlowGraph.h"
+
+#include "LOICollectionA/frontend/ir/opt/passes/CSEPass.h"
+
+namespace LOICollection::frontend::ir::opt {
+    namespace {
+        struct Val {
+            std::string key;
+            int start = 0;
+            std::vector<int> readSlots;
+            bool atom = false;
+        };
+
+        struct Avail {
+            int slot = -1;
+            int firstOpPos = -1;
+            bool spilled = false;
+            std::vector<int> readSlots;
+        };
+
+        bool isBarrier(OpCode op) {
+            return canWriteVariables(op)
+                || op == OpCode::LOAD_FIELD
+                || op == OpCode::LOAD_INDEX
+                || op == OpCode::STORE_INDEX
+                || op == OpCode::MAKE_ARRAY
+                || op == OpCode::MAKE_LAMBDA;
+        }
+
+        bool isPureBinary(OpCode op) {
+            switch (op) {
+                case OpCode::ADD:
+                case OpCode::SUB:
+                case OpCode::MUL:
+                case OpCode::DIV:
+                case OpCode::MOD:
+                case OpCode::POW:
+                case OpCode::CMP_EQ:
+                case OpCode::CMP_NE:
+                case OpCode::CMP_GT:
+                case OpCode::CMP_LT:
+                case OpCode::CMP_GE:
+                case OpCode::CMP_LE:
+                    return true;
+                default:
+                    return false;
+            }
+        }
+
+        bool isPureUnary(OpCode op) {
+            switch (op) {
+                case OpCode::NEG:
+                case OpCode::NOT:
+                case OpCode::INSTANCEOF:
+                case OpCode::LOAD_LEN:
+                case OpCode::DUP_IS_NONE:
+                    return true;
+                default:
+                    return false;
+            }
+        }
+
+        bool isLeaf(OpCode op) {
+            switch (op) {
+                case OpCode::LOAD_SLOT:
+                case OpCode::LOAD_VAR:
+                case OpCode::LOAD_THIS:
+                case OpCode::PUSH_INT:
+                case OpCode::PUSH_FLOAT:
+                case OpCode::PUSH_STR:
+                case OpCode::PUSH_BOOL:
+                case OpCode::PUSH_NONE:
+                    return true;
+                default:
+                    return false;
+            }
+        }
+
+        bool isStackReset(OpCode op) {
+            switch (op) {
+                case OpCode::ROT3:
+                case OpCode::SWAP2:
+                case OpCode::DUP2:
+                case OpCode::UNWRAP:
+                case OpCode::BIND_THIS:
+                    return true;
+                default:
+                    return false;
+            }
+        }
+
+        std::string opName(OpCode op) {
+            switch (op) {
+                case OpCode::ADD: return "ADD";
+                case OpCode::SUB: return "SUB";
+                case OpCode::MUL: return "MUL";
+                case OpCode::DIV: return "DIV";
+                case OpCode::MOD: return "MOD";
+                case OpCode::POW: return "POW";
+                case OpCode::CMP_EQ: return "EQ";
+                case OpCode::CMP_NE: return "NE";
+                case OpCode::CMP_GT: return "GT";
+                case OpCode::CMP_LT: return "LT";
+                case OpCode::CMP_GE: return "GE";
+                case OpCode::CMP_LE: return "LE";
+                case OpCode::NEG: return "NEG";
+                case OpCode::NOT: return "NOT";
+                case OpCode::INSTANCEOF: return "INST";
+                case OpCode::LOAD_LEN: return "LEN";
+                case OpCode::DUP_IS_NONE: return "ISNONE";
+                default: return "?";
+            }
+        }
+
+        std::string constKey(OpCode op, int operand) {
+            switch (op) {
+                case OpCode::PUSH_INT: return "I:" + std::to_string(operand);
+                case OpCode::PUSH_FLOAT: return "F:" + std::to_string(operand);
+                case OpCode::PUSH_STR: return "S:" + std::to_string(operand);
+                case OpCode::PUSH_BOOL: return "B:" + std::to_string(operand);
+                case OpCode::PUSH_NONE: return "N";
+                default: return "?";
+            }
+        }
+
+        void apply(std::vector<Instruction>& code, std::vector<CSEPass::Edit>& edits) {
+            std::sort(edits.begin(), edits.end(),
+                [](const CSEPass::Edit& a, const CSEPass::Edit& b) { return a.at < b.at; });
+
+            std::vector<Instruction> rewritten;
+            rewritten.reserve(code.size());
+
+            const int n = static_cast<int>(code.size());
+            size_t ei = 0;
+
+            for (int pos = 0; pos <= n; ++pos) {
+                while (ei < edits.size() && edits[ei].at == pos) {
+                    for (const Instruction& ins : edits[ei].insert)
+                        rewritten.push_back(ins);
+                    ++ei;
+                }
+
+                if (pos == n)
+                    break;
+
+                bool erased = false;
+                for (const CSEPass::Edit& e : edits)
+                    if (e.at <= pos && pos < e.eraseTo) {
+                        erased = true;
+                        break;
+                    }
+
+                if (!erased)
+                    rewritten.push_back(code[pos]);
+            }
+
+            while (ei < edits.size()) {
+                for (const Instruction& ins : edits[ei].insert)
+                    rewritten.push_back(ins);
+                ++ei;
+            }
+
+            code = std::move(rewritten);
+        }
+    }
+
+    size_t CSEPass::run() {
+        ControlFlowGraph cfg{ mChunk.code };
+
+        int nextSlot = mChunk.slotCount;
+        std::vector<Instruction> out;
+        out.reserve(mChunk.code.size());
+        std::vector<Edit> edits;
+        size_t eliminated = 0;
+
+        for (const ControlFlowGraph::Block& block : cfg.blocks()) {
+            std::vector<Val> vstack;
+            std::unordered_map<std::string, Avail> avail;
+
+            auto invalidate = [&](int slot) {
+                for (auto it = avail.begin(); it != avail.end();) {
+                    bool hit = false;
+                    for (int s : it->second.readSlots)
+                        if (s == slot) {
+                            hit = true;
+                            break;
+                        }
+                    if (hit)
+                        it = avail.erase(it);
+                    else
+                        ++it;
+                }
+            };
+
+            auto pop = [&]() -> Val {
+                if (vstack.empty())
+                    return Val{};
+                Val v = vstack.back();
+                vstack.pop_back();
+                return v;
+            };
+
+            for (int i = block.begin; i < block.end; ++i) {
+                const Instruction& ins = mChunk.code[i];
+                const OpCode op = ins.op;
+                const SourceLocation loc = ins.loc;
+
+                if (isLeaf(op)) {
+                    std::string key;
+                    std::vector<int> rs;
+
+                    if (op == OpCode::LOAD_SLOT || op == OpCode::LOAD_VAR) {
+                        key = (op == OpCode::LOAD_SLOT ? "L" : "V") + std::to_string(ins.operand);
+                        rs.push_back(ins.operand);
+                    } else if (op == OpCode::LOAD_THIS) {
+                        key = "THIS";
+                    } else {
+                        key = constKey(op, ins.operand);
+                    }
+
+                    const int start = static_cast<int>(out.size());
+                    out.push_back(ins);
+                    vstack.push_back(Val{ key, start, rs, true });
+                    continue;
+                }
+
+                if (op == OpCode::DUP) {
+                    if (!vstack.empty())
+                        vstack.push_back(vstack.back());
+                    out.push_back(ins);
+                    continue;
+                }
+
+                if (op == OpCode::POP) {
+                    if (!vstack.empty())
+                        vstack.pop_back();
+                    out.push_back(ins);
+                    continue;
+                }
+
+                if (op == OpCode::STORE_SLOT || op == OpCode::STORE_VAR) {
+                    out.push_back(ins);
+                    pop();
+                    invalidate(ins.operand);
+                    continue;
+                }
+
+                if (isPureBinary(op)) {
+                    Val right = pop();
+                    Val left = pop();
+
+                    if (left.key.empty() || right.key.empty()) {
+                        out.push_back(ins);
+                        vstack.push_back(Val{});
+                        continue;
+                    }
+
+                    std::string key = opName(op) + "(" + left.key + "," + right.key + ")";
+                    std::vector<int> rs = left.readSlots;
+                    rs.insert(rs.end(), right.readSlots.begin(), right.readSlots.end());
+                    const int curStart = std::min(left.start, right.start);
+
+                    auto it = avail.find(key);
+                    if (it != avail.end() && it->second.spilled && left.atom && right.atom) {
+                        edits.push_back({ curStart, static_cast<int>(out.size()),
+                            { Instruction{ OpCode::LOAD_SLOT, it->second.slot, loc } } });
+                        ++eliminated;
+                        vstack.push_back(Val{ key, curStart, rs, true });
+                    } else {
+                        if (it != avail.end() && left.atom && right.atom) {
+                            const int s = nextSlot++;
+                            it->second.slot = s;
+                            it->second.spilled = true;
+                            edits.push_back({ it->second.firstOpPos + 1, -1,
+                                { Instruction{ OpCode::DUP_STORE_SLOT, s, mChunk.code[it->second.firstOpPos].loc } } });
+                            edits.push_back({ curStart, static_cast<int>(out.size()),
+                                { Instruction{ OpCode::LOAD_SLOT, s, loc } } });
+                            ++eliminated;
+                            vstack.push_back(Val{ key, curStart, rs, true });
+                        } else {
+                            out.push_back(ins);
+                            const int p = static_cast<int>(out.size()) - 1;
+                            avail[key] = Avail{ -1, p, false, rs };
+                            vstack.push_back(Val{ key, curStart, rs, false });
+                        }
+                    }
+                    continue;
+                }
+
+                if (isPureUnary(op)) {
+                    Val arg = pop();
+
+                    if (arg.key.empty()) {
+                        out.push_back(ins);
+                        vstack.push_back(Val{});
+                        continue;
+                    }
+
+                    std::string key = opName(op) + "(" + arg.key + ")";
+                    const int curStart = arg.start;
+
+                    auto it = avail.find(key);
+                    if (it != avail.end() && it->second.spilled && arg.atom) {
+                        edits.push_back({ curStart, static_cast<int>(out.size()),
+                            { Instruction{ OpCode::LOAD_SLOT, it->second.slot, loc } } });
+                        ++eliminated;
+                        vstack.push_back(Val{ key, curStart, arg.readSlots, true });
+                    } else if (it != avail.end() && arg.atom) {
+                        const int s = nextSlot++;
+                        it->second.slot = s;
+                        it->second.spilled = true;
+                        edits.push_back({ it->second.firstOpPos + 1, -1,
+                            { Instruction{ OpCode::DUP_STORE_SLOT, s, mChunk.code[it->second.firstOpPos].loc } } });
+                        edits.push_back({ curStart, static_cast<int>(out.size()),
+                            { Instruction{ OpCode::LOAD_SLOT, s, loc } } });
+                        ++eliminated;
+                        vstack.push_back(Val{ key, curStart, arg.readSlots, true });
+                    } else {
+                        out.push_back(ins);
+                        const int p = static_cast<int>(out.size()) - 1;
+                        avail[key] = Avail{ -1, p, false, arg.readSlots };
+                        vstack.push_back(Val{ key, curStart, arg.readSlots, false });
+                    }
+                    continue;
+                }
+
+                out.push_back(ins);
+                vstack.clear();
+                if (isBarrier(op))
+                    avail.clear();
+            }
+        }
+
+        apply(out, edits);
+        mChunk.code = std::move(out);
+        mChunk.slotCount = nextSlot;
+
+        return eliminated;
+    }
+}

--- a/src/LOICollectionA/frontend/ir/opt/passes/CSEPass.h
+++ b/src/LOICollectionA/frontend/ir/opt/passes/CSEPass.h
@@ -1,0 +1,24 @@
+#pragma once
+
+#include <vector>
+
+#include "LOICollectionA/frontend/ir/ByteCode.h"
+
+namespace LOICollection::frontend::ir::opt {
+    class CSEPass {
+    public:
+        explicit CSEPass(BytecodeChunk& chunk)
+        : mChunk(chunk) {}
+
+        size_t run();
+
+        struct Edit {
+            int at = 0;
+            int eraseTo = -1;
+            std::vector<Instruction> insert;
+        };
+
+    private:
+        BytecodeChunk& mChunk;
+    };
+}

--- a/src/LOICollectionA/frontend/ir/opt/passes/ConstantFoldPass.cpp
+++ b/src/LOICollectionA/frontend/ir/opt/passes/ConstantFoldPass.cpp
@@ -27,7 +27,7 @@ namespace {
     }
 
     bool applyUnaryOperator(OpCode op, const ValueNode::ValueType& value, ValueNode::ValueType& out) {
-        if (op == OpCode::NEG) {
+        if (op == OpCode::NEG || op == OpCode::NEG_I) {
             DiagnosticEngine foldDiag;
             out = VM::applyUnary(value, OpCode::NEG, foldDiag);
             return !foldDiag.hasErrors();
@@ -129,9 +129,14 @@ namespace {
             case OpCode::DIV:
             case OpCode::MOD:
             case OpCode::POW:
+            case OpCode::ADD_I:
+            case OpCode::SUB_I:
+            case OpCode::MUL_I:
+            case OpCode::MOD_I:
                 return foldArithmetic(instr, oldIdx);
 
             case OpCode::NEG:
+            case OpCode::NEG_I:
             case OpCode::NOT:
                 return foldUnary(instr, oldIdx);
 
@@ -141,6 +146,12 @@ namespace {
             case OpCode::CMP_LT:
             case OpCode::CMP_GE:
             case OpCode::CMP_LE:
+            case OpCode::CMP_EQ_I:
+            case OpCode::CMP_NE_I:
+            case OpCode::CMP_GT_I:
+            case OpCode::CMP_LT_I:
+            case OpCode::CMP_GE_I:
+            case OpCode::CMP_LE_I:
             case OpCode::LOGIC_AND:
             case OpCode::LOGIC_OR:
                 return foldComparison(instr, oldIdx);
@@ -377,7 +388,10 @@ namespace {
             return {};
         }
 
-        if ((instr.op == OpCode::ADD || instr.op == OpCode::MUL) && identityEligible(instr.op, right, left)) {
+        const bool identityOp = instr.op == OpCode::ADD || instr.op == OpCode::MUL ||
+            instr.op == OpCode::ADD_I || instr.op == OpCode::MUL_I;
+
+        if (identityOp && identityEligible(instr.op, right, left)) {
             mCtx.drop(knownValue(left).producer);
             mCtx.stack.emplace_back(knownValue(right));
             ++mCtx.stats.folded;

--- a/src/LOICollectionA/frontend/ir/opt/passes/ConstantFoldPass.cpp
+++ b/src/LOICollectionA/frontend/ir/opt/passes/ConstantFoldPass.cpp
@@ -66,7 +66,7 @@ namespace LOICollection::frontend::ir::opt {
             }
             return false;
         }
-}
+    }
 
     void ConstantFoldPass::run(bool enabled) {
         for (size_t i = 0; i < mChunk.code.size(); ++i) {

--- a/src/LOICollectionA/frontend/ir/opt/passes/ConstantFoldPass.cpp
+++ b/src/LOICollectionA/frontend/ir/opt/passes/ConstantFoldPass.cpp
@@ -181,8 +181,6 @@ namespace {
     }
 
     ConstantFoldPass::Step ConstantFoldPass::foldNullish(const Instruction& instr, int oldIdx) {
-        // Fuse a preceding untargeted DUP into the test: DUP_IS_NONE keeps the operand
-        // on the stack instead of duplicating it first.
         const bool fusable = instr.op == OpCode::IS_NONE && oldIdx > 0 &&
             mChunk.code[oldIdx - 1].op == OpCode::DUP &&
             !mJumps.isTarget(oldIdx) && !mJumps.isTarget(oldIdx - 1) &&
@@ -729,8 +727,6 @@ namespace {
         const StackEntry cond = popEntry(mCtx.stack);
         const bool targeted = mJumps.isTarget(oldIdx);
 
-        // `if c then X else X` — both arms land on the same place, so the branch itself
-        // is dead and only the condition's side effects remain.
         const bool deadElse = oldIdx + 1 < static_cast<int>(mChunk.code.size()) &&
             mChunk.code[oldIdx + 1].op == OpCode::JMP &&
             !targeted && !mJumps.isTarget(oldIdx + 1) &&
@@ -768,9 +764,6 @@ namespace {
             return step;
         }
 
-        // A constant condition that other code still reads cannot be dropped, but the
-        // branch can still become unconditional when the producing push is only ever
-        // re-entered by backward jumps.
         if (isKnown(cond) && !knownValue(cond).removable && isScalarValue(knownValue(cond).value) &&
             alwaysJumps(instr.op, knownValue(cond).value) &&
             reachedOnlyByBackwardJumps(knownValue(cond).producer)) {
@@ -782,8 +775,6 @@ namespace {
             return { mCtx.emit({ OpCode::JMP, instr.operand, instr.loc }), false };
         }
 
-        // Fuse a preceding untargeted NOT into the branch: invert the condition instead
-        // of computing its negation at runtime.
         const bool fusable = oldIdx > 0 && mChunk.code[oldIdx - 1].op == OpCode::NOT &&
             !targeted && !mJumps.isTarget(oldIdx - 1) &&
             !mCtx.foldedCode.empty() && mCtx.foldedCode.back().op == OpCode::NOT;

--- a/src/LOICollectionA/frontend/ir/opt/passes/ConstantFoldPass.cpp
+++ b/src/LOICollectionA/frontend/ir/opt/passes/ConstantFoldPass.cpp
@@ -37,7 +37,6 @@ namespace {
         return true;
     }
 
-    // Mirrors ArrayClass::valuesEqual: int/float compare numerically, the rest by identity.
     bool valuesEqual(const ValueNode::ValueType& left, const ValueNode::ValueType& right) {
         if (auto li = std::get_if<int>(&left)) {
             if (auto ri = std::get_if<int>(&right)) return *li == *ri;

--- a/src/LOICollectionA/frontend/ir/opt/passes/ConstantFoldPass.cpp
+++ b/src/LOICollectionA/frontend/ir/opt/passes/ConstantFoldPass.cpp
@@ -354,15 +354,15 @@ namespace {
         const StackEntry left = popEntry(mCtx.stack);
 
         if (isKnown(left) && isKnown(right) && knownValue(left).removable && knownValue(right).removable) {
-            mCtx.drop(knownValue(left).producer);
-            mCtx.drop(knownValue(right).producer);
-
             DiagnosticEngine foldDiag;
             const ValueNode::ValueType result = VM::applyArithmetic(
                 knownValue(left).value, knownValue(right).value, instr.op, foldDiag);
 
             if (foldDiag.hasErrors())
                 return emitUnknown(instr);
+
+            mCtx.drop(knownValue(left).producer);
+            mCtx.drop(knownValue(right).producer);
 
             const int at = emitConstant(result, instr.loc);
 
@@ -397,8 +397,6 @@ namespace {
         if (!isKnown(operand) || !knownValue(operand).removable)
             return emitUnknown(instr);
 
-        mCtx.drop(knownValue(operand).producer);
-
         ValueNode::ValueType result;
         const bool foldable = applyUnaryOperator(instr.op, knownValue(operand).value, result);
 
@@ -406,6 +404,8 @@ namespace {
 
         if (!foldable)
             return emitUnknown(instr);
+
+        mCtx.drop(knownValue(operand).producer);
 
         const int at = emitConstant(result, instr.loc);
 
@@ -420,9 +420,6 @@ namespace {
 
         if (!isKnown(left) || !isKnown(right) || !knownValue(left).removable || !knownValue(right).removable)
             return emitUnknown(instr);
-
-        mCtx.drop(knownValue(left).producer);
-        mCtx.drop(knownValue(right).producer);
 
         bool result;
 
@@ -440,6 +437,9 @@ namespace {
             if (foldDiag.hasErrors())
                 return emitUnknown(instr);
         }
+
+        mCtx.drop(knownValue(left).producer);
+        mCtx.drop(knownValue(right).producer);
 
         const int at = emitConstant(result, instr.loc);
 

--- a/src/LOICollectionA/frontend/ir/opt/passes/ConstantFoldPass.cpp
+++ b/src/LOICollectionA/frontend/ir/opt/passes/ConstantFoldPass.cpp
@@ -27,7 +27,7 @@ namespace {
     bool applyUnaryOperator(OpCode op, const ValueNode::ValueType& value, ValueNode::ValueType& out) {
         if (op == OpCode::NEG) {
             DiagnosticEngine foldDiag;
-            out = VM::applyUnary(value, "-", foldDiag);
+            out = VM::applyUnary(value, OpCode::NEG, foldDiag);
             return !foldDiag.hasErrors();
         }
 
@@ -323,7 +323,7 @@ namespace {
 
             DiagnosticEngine foldDiag;
             const ValueNode::ValueType result = VM::applyArithmetic(
-                knownValue(left).value, knownValue(right).value, arithmeticOpName(instr.op), foldDiag);
+                knownValue(left).value, knownValue(right).value, instr.op, foldDiag);
 
             if (foldDiag.hasErrors())
                 return emitUnknown(instr);
@@ -399,7 +399,7 @@ namespace {
             DiagnosticEngine foldDiag;
 
             result = VM::applyComparison(
-                knownValue(left).value, knownValue(right).value, comparisonOpName(instr.op), foldDiag);
+                knownValue(left).value, knownValue(right).value, instr.op, foldDiag);
 
             if (foldDiag.hasErrors())
                 return emitUnknown(instr);

--- a/src/LOICollectionA/frontend/ir/opt/passes/ConstantFoldPass.cpp
+++ b/src/LOICollectionA/frontend/ir/opt/passes/ConstantFoldPass.cpp
@@ -16,56 +16,56 @@
 #include "LOICollectionA/frontend/ir/opt/passes/ConstantFoldPass.h"
 
 namespace LOICollection::frontend::ir::opt {
-namespace {
-    bool alwaysJumps(OpCode op, const ValueNode::ValueType& value) {
-        const bool truthy = VM::valueToBool(value);
-        return (op == OpCode::JMP_IF_FALSE) ? !truthy : truthy;
-    }
-
-    OpCode invertedBranch(OpCode op) {
-        return op == OpCode::JMP_IF_FALSE ? OpCode::JMP_IF_TRUE : OpCode::JMP_IF_FALSE;
-    }
-
-    bool applyUnaryOperator(OpCode op, const ValueNode::ValueType& value, ValueNode::ValueType& out) {
-        if (op == OpCode::NEG || op == OpCode::NEG_I) {
-            DiagnosticEngine foldDiag;
-            out = VM::applyUnary(value, OpCode::NEG, foldDiag);
-            return !foldDiag.hasErrors();
+    namespace {
+        bool alwaysJumps(OpCode op, const ValueNode::ValueType& value) {
+            const bool truthy = VM::valueToBool(value);
+            return (op == OpCode::JMP_IF_FALSE) ? !truthy : truthy;
         }
 
-        out = !VM::valueToBool(value);
-        return true;
-    }
+        OpCode invertedBranch(OpCode op) {
+            return op == OpCode::JMP_IF_FALSE ? OpCode::JMP_IF_TRUE : OpCode::JMP_IF_FALSE;
+        }
 
-    bool valuesEqual(const ValueNode::ValueType& left, const ValueNode::ValueType& right) {
-        if (auto li = std::get_if<int>(&left)) {
-            if (auto ri = std::get_if<int>(&right)) return *li == *ri;
-            if (auto rf = std::get_if<float>(&right)) return *li == *rf;
+        bool applyUnaryOperator(OpCode op, const ValueNode::ValueType& value, ValueNode::ValueType& out) {
+            if (op == OpCode::NEG || op == OpCode::NEG_I) {
+                DiagnosticEngine foldDiag;
+                out = VM::applyUnary(value, OpCode::NEG, foldDiag);
+                return !foldDiag.hasErrors();
+            }
+
+            out = !VM::valueToBool(value);
+            return true;
+        }
+
+        bool valuesEqual(const ValueNode::ValueType& left, const ValueNode::ValueType& right) {
+            if (auto li = std::get_if<int>(&left)) {
+                if (auto ri = std::get_if<int>(&right)) return *li == *ri;
+                if (auto rf = std::get_if<float>(&right)) return *li == *rf;
+                return false;
+            }
+            if (auto lf = std::get_if<float>(&left)) {
+                if (auto ri = std::get_if<int>(&right)) return *lf == *ri;
+                if (auto rf = std::get_if<float>(&right)) return *lf == *rf;
+                return false;
+            }
+            if (auto ls = std::get_if<std::string>(&left)) {
+                if (auto rs = std::get_if<std::string>(&right)) return *ls == *rs;
+                return false;
+            }
+            if (auto lb = std::get_if<bool>(&left)) {
+                if (auto rb = std::get_if<bool>(&right)) return *lb == *rb;
+                return false;
+            }
+            if (auto lo = std::get_if<ObjectRef>(&left)) {
+                if (auto ro = std::get_if<ObjectRef>(&right)) return *lo == *ro;
+                return false;
+            }
+            if (auto la = std::get_if<ArrayRef>(&left)) {
+                if (auto ra = std::get_if<ArrayRef>(&right)) return *la == *ra;
+                return false;
+            }
             return false;
         }
-        if (auto lf = std::get_if<float>(&left)) {
-            if (auto ri = std::get_if<int>(&right)) return *lf == *ri;
-            if (auto rf = std::get_if<float>(&right)) return *lf == *rf;
-            return false;
-        }
-        if (auto ls = std::get_if<std::string>(&left)) {
-            if (auto rs = std::get_if<std::string>(&right)) return *ls == *rs;
-            return false;
-        }
-        if (auto lb = std::get_if<bool>(&left)) {
-            if (auto rb = std::get_if<bool>(&right)) return *lb == *rb;
-            return false;
-        }
-        if (auto lo = std::get_if<ObjectRef>(&left)) {
-            if (auto ro = std::get_if<ObjectRef>(&right)) return *lo == *ro;
-            return false;
-        }
-        if (auto la = std::get_if<ArrayRef>(&left)) {
-            if (auto ra = std::get_if<ArrayRef>(&right)) return *la == *ra;
-            return false;
-        }
-        return false;
-    }
 }
 
     void ConstantFoldPass::run(bool enabled) {

--- a/src/LOICollectionA/frontend/ir/opt/passes/ConstantFoldPass.cpp
+++ b/src/LOICollectionA/frontend/ir/opt/passes/ConstantFoldPass.cpp
@@ -1,10 +1,12 @@
 #include <algorithm>
+#include <charconv>
 #include <memory>
 #include <string>
 #include <variant>
 #include <vector>
 
 #include "LOICollectionA/frontend/DiagnosticEngine.h"
+#include "LOICollectionA/frontend/Unicode.h"
 
 #include "LOICollectionA/frontend/ir/VM.h"
 
@@ -33,6 +35,37 @@ namespace {
 
         out = !VM::valueToBool(value);
         return true;
+    }
+
+    // Mirrors ArrayClass::valuesEqual: int/float compare numerically, the rest by identity.
+    bool valuesEqual(const ValueNode::ValueType& left, const ValueNode::ValueType& right) {
+        if (auto li = std::get_if<int>(&left)) {
+            if (auto ri = std::get_if<int>(&right)) return *li == *ri;
+            if (auto rf = std::get_if<float>(&right)) return *li == *rf;
+            return false;
+        }
+        if (auto lf = std::get_if<float>(&left)) {
+            if (auto ri = std::get_if<int>(&right)) return *lf == *ri;
+            if (auto rf = std::get_if<float>(&right)) return *lf == *rf;
+            return false;
+        }
+        if (auto ls = std::get_if<std::string>(&left)) {
+            if (auto rs = std::get_if<std::string>(&right)) return *ls == *rs;
+            return false;
+        }
+        if (auto lb = std::get_if<bool>(&left)) {
+            if (auto rb = std::get_if<bool>(&right)) return *lb == *rb;
+            return false;
+        }
+        if (auto lo = std::get_if<ObjectRef>(&left)) {
+            if (auto ro = std::get_if<ObjectRef>(&right)) return *lo == *ro;
+            return false;
+        }
+        if (auto la = std::get_if<ArrayRef>(&left)) {
+            if (auto ra = std::get_if<ArrayRef>(&right)) return *la == *ra;
+            return false;
+        }
+        return false;
     }
 }
 
@@ -124,6 +157,9 @@ namespace {
 
             case OpCode::CALL:
                 return foldCall(instr, oldIdx);
+
+            case OpCode::CALL_NATIVE_METHOD:
+                return foldNativeMethod(instr, oldIdx);
 
             case OpCode::JMP_IF_FALSE:
             case OpCode::JMP_IF_TRUE:
@@ -538,6 +574,152 @@ namespace {
 
         const int at = emitConstant(result, instr.loc);
 
+        mCtx.stack.emplace_back(TrackedValue{ result, at, !mJumps.isTarget(oldIdx) });
+        ++mCtx.stats.folded;
+
+        return { at, false };
+    }
+
+    ConstantFoldPass::Step ConstantFoldPass::foldNativeMethod(const Instruction& instr, int oldIdx) {
+        if (instr.operand < 0 || instr.operand >= static_cast<int>(mChunk.nativeCalls.size()))
+            return emitOpaque(instr);
+
+        const auto& meta = mChunk.nativeCalls[instr.operand];
+
+        if (meta.isStatic || static_cast<int>(mCtx.stack.size()) <= meta.argCount + 1)
+            return emitOpaque(instr);
+
+        const StackEntry receiver = popEntry(mCtx.stack);
+        std::vector<StackEntry> args(meta.argCount);
+        for (int i = 0; i < meta.argCount; ++i)
+            args[meta.argCount - 1 - i] = popEntry(mCtx.stack);
+
+        if (!isKnown(receiver) || !knownValue(receiver).removable)
+            return emitOpaque(instr);
+        for (const auto& arg : args)
+            if (!isKnown(arg) || !knownValue(arg).removable)
+                return emitOpaque(instr);
+
+        const auto& recv = knownValue(receiver).value;
+
+        ValueNode::ValueType result;
+        bool folded = false;
+
+        if (std::holds_alternative<std::string>(recv)) {
+            const auto& s = std::get<std::string>(recv);
+
+            if (meta.name == "length" && meta.argCount == 0) {
+                result = static_cast<int>(codepointCount(s));
+                folded = true;
+            } else if (meta.name == "contains" && meta.argCount == 1) {
+                result = s.find(std::get<std::string>(knownValue(args[0]).value)) != std::string::npos;
+                folded = true;
+            } else if (meta.name == "startsWith" && meta.argCount == 1) {
+                const auto& p = std::get<std::string>(knownValue(args[0]).value);
+                result = s.size() >= p.size() && s.compare(0, p.size(), p) == 0;
+                folded = true;
+            } else if (meta.name == "endsWith" && meta.argCount == 1) {
+                const auto& p = std::get<std::string>(knownValue(args[0]).value);
+                result = s.size() >= p.size() && s.compare(s.size() - p.size(), p.size(), p) == 0;
+                folded = true;
+            } else if (meta.name == "indexOf" && meta.argCount == 1) {
+                const auto& needle = std::get<std::string>(knownValue(args[0]).value);
+                const size_t pos = s.find(needle);
+                result = pos == std::string::npos ? -1 : static_cast<int>(codepointDistance(s, pos));
+                folded = true;
+            } else if (meta.name == "split" && meta.argCount == 1) {
+                const auto& sep = std::get<std::string>(knownValue(args[0]).value);
+                auto arr = std::make_shared<ArrayValue>();
+                if (sep.empty()) {
+                    for (size_t i = 0; i < s.size(); i += codepointWidth(s[i]))
+                        arr->elements.emplace_back(s.substr(i, codepointWidth(s[i])));
+                } else {
+                    size_t start = 0;
+                    while (true) {
+                        const size_t pos = s.find(sep, start);
+                        if (pos == std::string::npos) {
+                            arr->elements.emplace_back(s.substr(start));
+                            break;
+                        }
+                        arr->elements.emplace_back(s.substr(start, pos - start));
+                        start = pos + sep.size();
+                    }
+                }
+                result = arr;
+                folded = true;
+            } else if (meta.name == "toInt" && meta.argCount == 0) {
+                int v = 0;
+                const auto [ptr, ec] = std::from_chars(s.data(), s.data() + s.size(), v);
+                if (ec == std::errc{} && ptr == s.data() + s.size()) {
+                    result = v;
+                    folded = true;
+                }
+            } else if (meta.name == "toFloat" && meta.argCount == 0) {
+                float v = 0.0f;
+                const auto [ptr, ec] = std::from_chars(s.data(), s.data() + s.size(), v);
+                if (ec == std::errc{} && ptr == s.data() + s.size()) {
+                    result = v;
+                    folded = true;
+                }
+            }
+        } else if (std::holds_alternative<ArrayRef>(recv)) {
+            const auto& arr = std::get<ArrayRef>(recv);
+
+            if (meta.name == "length" && meta.argCount == 0) {
+                result = static_cast<int>(arr->elements.size());
+                folded = true;
+            } else if (meta.name == "contains" && meta.argCount == 1) {
+                const auto& needle = knownValue(args[0]).value;
+                bool found = false;
+                for (const auto& element : arr->elements) {
+                    if (valuesEqual(element, needle)) {
+                        found = true;
+                        break;
+                    }
+                }
+                result = found;
+                folded = true;
+            } else if (meta.name == "indexOf" && meta.argCount == 1) {
+                const auto& needle = knownValue(args[0]).value;
+                int found = -1;
+                for (size_t i = 0; i < arr->elements.size(); ++i) {
+                    if (valuesEqual(arr->elements[i], needle)) {
+                        found = static_cast<int>(i);
+                        break;
+                    }
+                }
+                result = found;
+                folded = true;
+            } else if (meta.name == "join" && meta.argCount == 1) {
+                const auto& sep = std::get<std::string>(knownValue(args[0]).value);
+                std::string out;
+                for (size_t i = 0; i < arr->elements.size(); ++i) {
+                    if (i != 0)
+                        out += sep;
+                    out += VM::valueToString(arr->elements[i]);
+                }
+                result = out;
+                folded = true;
+            } else if (meta.name == "slice" && meta.argCount == 2) {
+                const int len = static_cast<int>(arr->elements.size());
+                const int start = std::clamp(std::get<int>(knownValue(args[0]).value), 0, len);
+                const int end = std::clamp(std::get<int>(knownValue(args[1]).value), 0, len);
+                auto out = std::make_shared<ArrayValue>();
+                if (start < end)
+                    out->elements.assign(arr->elements.begin() + start, arr->elements.begin() + end);
+                result = out;
+                folded = true;
+            }
+        }
+
+        if (!folded)
+            return emitOpaque(instr);
+
+        mCtx.drop(knownValue(receiver).producer);
+        for (const auto& arg : args)
+            mCtx.drop(knownValue(arg).producer);
+
+        const int at = emitConstant(result, instr.loc);
         mCtx.stack.emplace_back(TrackedValue{ result, at, !mJumps.isTarget(oldIdx) });
         ++mCtx.stats.folded;
 

--- a/src/LOICollectionA/frontend/ir/opt/passes/ConstantFoldPass.h
+++ b/src/LOICollectionA/frontend/ir/opt/passes/ConstantFoldPass.h
@@ -39,6 +39,7 @@ namespace LOICollection::frontend::ir::opt {
         Step foldStoreIndex(const Instruction& instr);
         Step foldCall(const Instruction& instr, int oldIdx);
         Step foldBranch(const Instruction& instr, int oldIdx);
+        Step foldNativeMethod(const Instruction& instr, int oldIdx);
 
         Step emitUnknown(const Instruction& instr);
         Step emitOpaque(const Instruction& instr);

--- a/src/LOICollectionA/frontend/ir/opt/passes/DeadCodePass.cpp
+++ b/src/LOICollectionA/frontend/ir/opt/passes/DeadCodePass.cpp
@@ -5,121 +5,121 @@
 #include "LOICollectionA/frontend/ir/opt/passes/DeadCodePass.h"
 
 namespace LOICollection::frontend::ir::opt {
-namespace {
-    class JumpChains {
-    public:
-        JumpChains(
-            const std::vector<Instruction>& folded,
-            const std::vector<int>& newToOld,
-            const std::vector<int>& oldToNew
-        )
-        : mFolded(folded),
-          mNewToOld(newToOld),
-          mOldToNew(oldToNew) {}
-
-        int targetOf(int j) const {
-            if (j < 0 || j >= static_cast<int>(mNewToOld.size()))
-                return -1;
-
-            int oldTarget = mNewToOld[j] + 1 + mFolded[j].operand;
-            if (oldTarget < 0 || oldTarget >= static_cast<int>(mOldToNew.size()))
-                return -1;
-
-            return mOldToNew[oldTarget];
-        }
-
-        int resolve(int j) const {
-            int target = targetOf(j);
-            int guard = 0;
-
-            while (target >= 0 && target < static_cast<int>(mFolded.size()) && mFolded[target].op == OpCode::JMP) {
-                if (++guard > static_cast<int>(mFolded.size()))
-                    break;
-
-                int next = targetOf(target);
-                if (next == target || next < 0)
-                    break;
-
-                target = next;
+    namespace {
+        class JumpChains {
+        public:
+            JumpChains(
+                const std::vector<Instruction>& folded,
+                const std::vector<int>& newToOld,
+                const std::vector<int>& oldToNew
+            )
+            : mFolded(folded),
+              mNewToOld(newToOld),
+              mOldToNew(oldToNew) {}
+    
+            int targetOf(int j) const {
+                if (j < 0 || j >= static_cast<int>(mNewToOld.size()))
+                    return -1;
+    
+                int oldTarget = mNewToOld[j] + 1 + mFolded[j].operand;
+                if (oldTarget < 0 || oldTarget >= static_cast<int>(mOldToNew.size()))
+                    return -1;
+    
+                return mOldToNew[oldTarget];
             }
-
-            return target;
-        }
-
-    private:
-        const std::vector<Instruction>& mFolded;
-        const std::vector<int>& mNewToOld;
-        const std::vector<int>& mOldToNew;
-    };
-
-    void compact(OptContext& ctx) {
-        std::vector<Instruction> compactCode;
-        std::vector<int> compactNewToOld;
-        std::vector<int> compactOldToNew(ctx.oldToNew.size(), -1);
-
-        for (size_t j = 0; j < ctx.foldedCode.size(); ++j) {
-            if (ctx.dropped[j])
-                continue;
-
-            compactOldToNew[ctx.newToOld[j]] = static_cast<int>(compactCode.size());
-            compactCode.push_back(ctx.foldedCode[j]);
-            compactNewToOld.push_back(ctx.newToOld[j]);
-        }
-
-        ctx.foldedCode = std::move(compactCode);
-        ctx.newToOld = std::move(compactNewToOld);
-        ctx.oldToNew = std::move(compactOldToNew);
-    }
-
-    std::vector<bool> markReachable(const std::vector<Instruction>& folded, const JumpChains& chains) {
-        std::vector<bool> reachable(folded.size(), false);
-        std::vector<int> queue;
-
-        reachable[0] = true;
-        queue.push_back(0);
-
-        while (!queue.empty()) {
-            int j = queue.back();
-            queue.pop_back();
-
-            auto mark = [&](int target) {
-                if (target >= 0 && target < static_cast<int>(folded.size()) && !reachable[target]) {
-                    reachable[target] = true;
-                    queue.push_back(target);
+    
+            int resolve(int j) const {
+                int target = targetOf(j);
+                int guard = 0;
+    
+                while (target >= 0 && target < static_cast<int>(mFolded.size()) && mFolded[target].op == OpCode::JMP) {
+                    if (++guard > static_cast<int>(mFolded.size()))
+                        break;
+    
+                    int next = targetOf(target);
+                    if (next == target || next < 0)
+                        break;
+    
+                    target = next;
                 }
-            };
-
-            if (isJump(folded[j].op))
-                mark(chains.resolve(j));
-
-            if (!isTerminator(folded[j].op))
-                mark(j + 1);
+    
+                return target;
+            }
+    
+        private:
+            const std::vector<Instruction>& mFolded;
+            const std::vector<int>& mNewToOld;
+            const std::vector<int>& mOldToNew;
+        };
+    
+        void compact(OptContext& ctx) {
+            std::vector<Instruction> compactCode;
+            std::vector<int> compactNewToOld;
+            std::vector<int> compactOldToNew(ctx.oldToNew.size(), -1);
+    
+            for (size_t j = 0; j < ctx.foldedCode.size(); ++j) {
+                if (ctx.dropped[j])
+                    continue;
+    
+                compactOldToNew[ctx.newToOld[j]] = static_cast<int>(compactCode.size());
+                compactCode.push_back(ctx.foldedCode[j]);
+                compactNewToOld.push_back(ctx.newToOld[j]);
+            }
+    
+            ctx.foldedCode = std::move(compactCode);
+            ctx.newToOld = std::move(compactNewToOld);
+            ctx.oldToNew = std::move(compactOldToNew);
         }
-
-        return reachable;
-    }
-
-    void remapJumps(
-        std::vector<Instruction>& finalCode,
-        const std::vector<int>& finalToFolded,
-        const std::vector<int>& foldedToFinal,
-        const JumpChains& chains,
-        bool thread
-    ) {
-        for (size_t f = 0; f < finalCode.size(); ++f) {
-            auto& instr = finalCode[f];
-            if (!isJump(instr.op))
-                continue;
-
-            int foldedIdx = finalToFolded[f];
-            int target = thread ? chains.resolve(foldedIdx) : chains.targetOf(foldedIdx);
-            int finalTarget = (target >= 0 && target < static_cast<int>(foldedToFinal.size()))
-                ? foldedToFinal[target] : static_cast<int>(f) + 1;
-
-            instr.operand = finalTarget - static_cast<int>(f) - 1;
+    
+        std::vector<bool> markReachable(const std::vector<Instruction>& folded, const JumpChains& chains) {
+            std::vector<bool> reachable(folded.size(), false);
+            std::vector<int> queue;
+    
+            reachable[0] = true;
+            queue.push_back(0);
+    
+            while (!queue.empty()) {
+                int j = queue.back();
+                queue.pop_back();
+    
+                auto mark = [&](int target) {
+                    if (target >= 0 && target < static_cast<int>(folded.size()) && !reachable[target]) {
+                        reachable[target] = true;
+                        queue.push_back(target);
+                    }
+                };
+    
+                if (isJump(folded[j].op))
+                    mark(chains.resolve(j));
+    
+                if (!isTerminator(folded[j].op))
+                    mark(j + 1);
+            }
+    
+            return reachable;
+        }
+    
+        void remapJumps(
+            std::vector<Instruction>& finalCode,
+            const std::vector<int>& finalToFolded,
+            const std::vector<int>& foldedToFinal,
+            const JumpChains& chains,
+            bool thread
+        ) {
+            for (size_t f = 0; f < finalCode.size(); ++f) {
+                auto& instr = finalCode[f];
+                if (!isJump(instr.op))
+                    continue;
+    
+                int foldedIdx = finalToFolded[f];
+                int target = thread ? chains.resolve(foldedIdx) : chains.targetOf(foldedIdx);
+                int finalTarget = (target >= 0 && target < static_cast<int>(foldedToFinal.size()))
+                    ? foldedToFinal[target] : static_cast<int>(f) + 1;
+    
+                instr.operand = finalTarget - static_cast<int>(f) - 1;
+            }
         }
     }
-}
 
     void DeadCodePass::run(BytecodeChunk& chunk, OptContext& ctx, bool eliminate) {
         compact(ctx);

--- a/src/LOICollectionA/frontend/ir/opt/passes/DeadStorePass.cpp
+++ b/src/LOICollectionA/frontend/ir/opt/passes/DeadStorePass.cpp
@@ -3,14 +3,14 @@
 #include "LOICollectionA/frontend/ir/opt/passes/DeadStorePass.h"
 
 namespace LOICollection::frontend::ir::opt {
-namespace {
-    bool capturesLocals(OpCode op) {
-        return op == OpCode::MAKE_LAMBDA;
-    }
+    namespace {
+        bool capturesLocals(OpCode op) {
+            return op == OpCode::MAKE_LAMBDA;
+        }
 
-    bool closesBlock(OpCode op) {
-        return isJump(op) || isTerminator(op) || canWriteVariables(op) || capturesLocals(op);
-    }
+        bool closesBlock(OpCode op) {
+            return isJump(op) || isTerminator(op) || canWriteVariables(op) || capturesLocals(op);
+        }
 }
 
     void DeadStorePass::run(bool enabled) {

--- a/src/LOICollectionA/frontend/ir/opt/passes/DeadStorePass.cpp
+++ b/src/LOICollectionA/frontend/ir/opt/passes/DeadStorePass.cpp
@@ -1,0 +1,98 @@
+#include "LOICollectionA/frontend/ir/opt/analysis/OpTraits.h"
+
+#include "LOICollectionA/frontend/ir/opt/passes/DeadStorePass.h"
+
+namespace LOICollection::frontend::ir::opt {
+namespace {
+    bool capturesLocals(OpCode op) {
+        return op == OpCode::MAKE_LAMBDA;
+    }
+
+    bool closesBlock(OpCode op) {
+        return isJump(op) || isTerminator(op) || canWriteVariables(op) || capturesLocals(op);
+    }
+}
+
+    void DeadStorePass::run(bool enabled) {
+        mPending.clear();
+
+        if (!enabled)
+            return;
+
+        for (size_t j = 0; j < mCtx.foldedCode.size(); ++j) {
+            if (j < mCtx.newToOld.size() && mJumps.isTarget(mCtx.newToOld[j])) {
+                mPending.clear();
+                continue;
+            }
+
+            const Instruction instr = mCtx.foldedCode[j];
+
+            switch (instr.op) {
+                case OpCode::LOAD_SLOT:
+                    mPending.erase(VariableKey{ instr.operand });
+                    break;
+
+                case OpCode::LOAD_VAR:
+                    mPending.erase(VariableKey{ std::get<std::string>(mChunk.constants[instr.operand]) });
+                    break;
+
+                case OpCode::STORE_SLOT:
+                case OpCode::DUP_STORE_SLOT:
+                    this->recordStore(VariableKey{ instr.operand }, static_cast<int>(j), instr.operand);
+                    break;
+
+                case OpCode::STORE_VAR:
+                case OpCode::DUP_STORE:
+                    this->recordStore(
+                        VariableKey{ std::get<std::string>(mChunk.constants[instr.operand]) },
+                        static_cast<int>(j),
+                        -1
+                    );
+                    break;
+
+                default:
+                    break;
+            }
+
+            if (closesBlock(instr.op))
+                mPending.clear();
+        }
+    }
+
+    void DeadStorePass::recordStore(const VariableKey& key, int at, int slot) {
+        if (slot >= mChunk.slotCount) {
+            mPending.clear();
+            return;
+        }
+
+        auto [it, inserted] = mPending.emplace(key, at);
+        if (inserted)
+            return;
+
+        this->killStore(it->second);
+
+        it->second = at;
+    }
+
+    void DeadStorePass::killStore(int at) {
+        Instruction& dead = mCtx.foldedCode[at];
+
+        switch (dead.op) {
+            case OpCode::STORE_SLOT:
+            case OpCode::STORE_VAR:
+                dead.op = OpCode::POP;
+                dead.operand = 0;
+                break;
+
+            case OpCode::DUP_STORE_SLOT:
+            case OpCode::DUP_STORE:
+                mCtx.dropped[at] = true;
+                break;
+
+            default:
+                return;
+        }
+
+        ++mCtx.stats.removed;
+    }
+}

--- a/src/LOICollectionA/frontend/ir/opt/passes/DeadStorePass.cpp
+++ b/src/LOICollectionA/frontend/ir/opt/passes/DeadStorePass.cpp
@@ -11,7 +11,7 @@ namespace LOICollection::frontend::ir::opt {
         bool closesBlock(OpCode op) {
             return isJump(op) || isTerminator(op) || canWriteVariables(op) || capturesLocals(op);
         }
-}
+    }
 
     void DeadStorePass::run(bool enabled) {
         mPending.clear();

--- a/src/LOICollectionA/frontend/ir/opt/passes/DeadStorePass.h
+++ b/src/LOICollectionA/frontend/ir/opt/passes/DeadStorePass.h
@@ -1,0 +1,34 @@
+#pragma once
+
+#include <string>
+#include <unordered_map>
+#include <variant>
+
+#include "LOICollectionA/frontend/ir/ByteCode.h"
+
+#include "LOICollectionA/frontend/ir/opt/OptContext.h"
+#include "LOICollectionA/frontend/ir/opt/analysis/JumpTargetAnalysis.h"
+
+namespace LOICollection::frontend::ir::opt {
+    class DeadStorePass {
+    public:
+        DeadStorePass(BytecodeChunk& chunk, OptContext& ctx, const JumpTargetAnalysis& jumps)
+        : mChunk(chunk),
+          mCtx(ctx),
+          mJumps(jumps) {}
+
+        void run(bool enabled);
+
+    private:
+        using VariableKey = std::variant<int, std::string>;
+
+        void recordStore(const VariableKey& key, int at, int slot);
+
+        void killStore(int at);
+
+        BytecodeChunk& mChunk;
+        OptContext& mCtx;
+        const JumpTargetAnalysis& mJumps;
+        std::unordered_map<VariableKey, int> mPending;
+    };
+}

--- a/src/LOICollectionA/frontend/ir/opt/passes/LICMPass.cpp
+++ b/src/LOICollectionA/frontend/ir/opt/passes/LICMPass.cpp
@@ -114,13 +114,6 @@ namespace LOICollection::frontend::ir::opt {
         const std::vector<bool> written = this->writtenSlots(cfg, loop);
         const auto& header = cfg.blocks()[loop.header];
 
-        // Pull the longest run of loop-invariant code off the top of the header. The
-        // hoisted sequence must leave exactly one value on the stack: the preheader
-        // computes it once, the header duplicates it for each iteration, and the single
-        // exit pops the leftover so every path stays balanced.
-        // A run that reaches below its own first value would read whatever the loop
-        // was entered with, and only the first iteration would see it: the back edge
-        // arrives with a different stack. Stop before such an instruction instead.
         std::vector<Instruction> invariant;
         int depth = 0;
         int net = 0;
@@ -150,8 +143,6 @@ namespace LOICollection::frontend::ir::opt {
 
         edits.push_back({ insertAt, false, -1, invariant });
 
-        // The header's first instruction is replaced in place by the DUP that feeds
-        // each iteration, so back edges that targeted it stay pointed at the header.
         edits.push_back({ header.begin, true, 0, { Instruction{ OpCode::DUP, 0, invariant.front().loc } } });
         for (int k = 1; k < static_cast<int>(invariant.size()); ++k)
             edits.push_back({ header.begin + k, true, -1, {} });
@@ -185,9 +176,6 @@ namespace LOICollection::frontend::ir::opt {
                     origin.push_back(-1);
                 }
 
-                // The first edit that asks for it decides where jumps to `at` now land:
-                // an insertion ahead of `at` (the balancing POP) and a replacement of
-                // `at` itself (the DUP) both have to own that address.
                 if (edits[e].retarget >= 0 && owner < 0)
                     owner = static_cast<int>(e);
 

--- a/src/LOICollectionA/frontend/ir/opt/passes/LICMPass.cpp
+++ b/src/LOICollectionA/frontend/ir/opt/passes/LICMPass.cpp
@@ -1,0 +1,237 @@
+#include <algorithm>
+
+#include "LOICollectionA/frontend/ir/opt/analysis/OpTraits.h"
+#include "LOICollectionA/frontend/ir/opt/analysis/StackEffect.h"
+
+#include "LOICollectionA/frontend/ir/opt/passes/LICMPass.h"
+
+namespace LOICollection::frontend::ir::opt {
+    size_t LICMPass::run() {
+        size_t hoisted = 0;
+
+        for (int round = 0; round < 4; ++round) {
+            const ControlFlowGraph cfg{ mChunk.code };
+
+            size_t moved = 0;
+            for (const auto& loop : findNaturalLoops(cfg))
+                moved += this->hoist(cfg, loop);
+
+            if (moved == 0)
+                break;
+
+            hoisted += moved;
+        }
+
+        return hoisted;
+    }
+
+    std::vector<bool> LICMPass::writtenSlots(const ControlFlowGraph& cfg, const NaturalLoop& loop) const {
+        const int slots = mChunk.slotCount > 0 ? mChunk.slotCount : 0;
+
+        std::vector<bool> written(slots, false);
+
+        for (const int block : loop.blocks) {
+            const auto& info = cfg.blocks()[block];
+
+            for (int i = info.begin; i < info.end; ++i) {
+                const Instruction& instr = mChunk.code[i];
+
+                if (instr.op != OpCode::STORE_SLOT && instr.op != OpCode::DUP_STORE_SLOT)
+                    continue;
+
+                if (instr.operand >= 0 && instr.operand < slots)
+                    written[instr.operand] = true;
+            }
+        }
+
+        return written;
+    }
+
+    bool LICMPass::isHoistable(const Instruction& instr, const std::vector<bool>& written) const {
+        switch (instr.op) {
+            case OpCode::PUSH_INT:
+            case OpCode::PUSH_FLOAT:
+            case OpCode::PUSH_STR:
+            case OpCode::PUSH_BOOL:
+            case OpCode::PUSH_NONE:
+            case OpCode::ADD:
+            case OpCode::SUB:
+            case OpCode::MUL:
+            case OpCode::DIV:
+            case OpCode::MOD:
+            case OpCode::POW:
+            case OpCode::CMP_EQ:
+            case OpCode::CMP_NE:
+            case OpCode::CMP_GT:
+            case OpCode::CMP_LT:
+            case OpCode::CMP_GE:
+            case OpCode::CMP_LE:
+            case OpCode::LOGIC_AND:
+            case OpCode::LOGIC_OR:
+            case OpCode::NEG:
+            case OpCode::NOT:
+            case OpCode::UNWRAP:
+            case OpCode::TYPE_OF:
+            case OpCode::HAS_VALUE:
+            case OpCode::IS_NONE:
+                return true;
+
+            case OpCode::LOAD_SLOT:
+                return instr.operand >= 0 && instr.operand < static_cast<int>(written.size()) &&
+                    !written[instr.operand];
+
+            default:
+                return false;
+        }
+    }
+
+    size_t LICMPass::hoist(const ControlFlowGraph& cfg, const NaturalLoop& loop) {
+        if (loop.entries.size() != 1 || loop.exits.size() != 1)
+            return 0;
+
+        const auto& entry = cfg.blocks()[loop.entries[0]];
+
+        if (entry.begin >= entry.end)
+            return 0;
+
+        if (entry.successors.size() != 1 || entry.successors[0] != loop.header)
+            return 0;
+
+        const int exitBlock = loop.exits[0];
+        for (const int predecessor : cfg.blocks()[exitBlock].predecessors)
+            if (!loop.contains(predecessor))
+                return 0;
+
+        for (const int block : loop.blocks) {
+            if (block == loop.header)
+                continue;
+
+            for (const int predecessor : cfg.blocks()[block].predecessors)
+                if (!loop.contains(predecessor))
+                    return 0;
+        }
+
+        const std::vector<bool> written = this->writtenSlots(cfg, loop);
+        const auto& header = cfg.blocks()[loop.header];
+
+        // Pull the longest run of loop-invariant code off the top of the header. The
+        // hoisted sequence must leave exactly one value on the stack: the preheader
+        // computes it once, the header duplicates it for each iteration, and the single
+        // exit pops the leftover so every path stays balanced.
+        // A run that reaches below its own first value would read whatever the loop
+        // was entered with, and only the first iteration would see it: the back edge
+        // arrives with a different stack. Stop before such an instruction instead.
+        std::vector<Instruction> invariant;
+        int depth = 0;
+        int net = 0;
+
+        for (int i = header.begin; i < header.end; ++i) {
+            StackEffect effect;
+            if (!stackEffectOf(mChunk.code[i], mChunk, effect))
+                break;
+            if (!this->isHoistable(mChunk.code[i], written))
+                break;
+            if (depth < effect.reach())
+                break;
+
+            invariant.push_back(mChunk.code[i]);
+            depth += effect.net();
+            net += effect.net();
+        }
+
+        if (invariant.empty() || net != 1)
+            return 0;
+
+        const int insertAt = mChunk.code[entry.end - 1].op == OpCode::JMP ? entry.end - 1 : entry.end;
+
+        const int exitBegin = cfg.blocks()[exitBlock].begin;
+
+        std::vector<Edit> edits;
+
+        edits.push_back({ insertAt, false, -1, invariant });
+
+        // The header's first instruction is replaced in place by the DUP that feeds
+        // each iteration, so back edges that targeted it stay pointed at the header.
+        edits.push_back({ header.begin, true, 0, { Instruction{ OpCode::DUP, 0, invariant.front().loc } } });
+        for (int k = 1; k < static_cast<int>(invariant.size()); ++k)
+            edits.push_back({ header.begin + k, true, -1, {} });
+
+        edits.push_back({ exitBegin, false, 0, { Instruction{ OpCode::POP, 0, {} } } });
+
+        apply(mChunk.code, edits);
+
+        return 1;
+    }
+
+    void LICMPass::apply(std::vector<Instruction>& code, const std::vector<Edit>& edits) {
+        const int last = static_cast<int>(code.size()) - 1;
+
+        std::vector<Instruction> rewritten;
+        std::vector<int> oldToNew(code.size(), -1);
+        std::vector<int> origin;
+        std::vector<std::vector<int>> placed(edits.size());
+
+        for (size_t i = 0; i <= code.size(); ++i) {
+            int owner = -1;
+            bool erased = false;
+
+            for (size_t e = 0; e < edits.size(); ++e) {
+                if (edits[e].at != static_cast<int>(i))
+                    continue;
+
+                for (const Instruction& instr : edits[e].insert) {
+                    placed[e].push_back(static_cast<int>(rewritten.size()));
+                    rewritten.push_back(instr);
+                    origin.push_back(-1);
+                }
+
+                // The first edit that asks for it decides where jumps to `at` now land:
+                // an insertion ahead of `at` (the balancing POP) and a replacement of
+                // `at` itself (the DUP) both have to own that address.
+                if (edits[e].retarget >= 0 && owner < 0)
+                    owner = static_cast<int>(e);
+
+                if (edits[e].erase)
+                    erased = true;
+            }
+
+            if (i == code.size())
+                break;
+
+            const bool redirected = owner >= 0 &&
+                edits[owner].retarget < static_cast<int>(placed[owner].size());
+
+            if (redirected)
+                oldToNew[i] = placed[owner][edits[owner].retarget];
+
+            if (erased)
+                continue;
+
+            if (!redirected)
+                oldToNew[i] = static_cast<int>(rewritten.size());
+
+            origin.push_back(static_cast<int>(i));
+            rewritten.push_back(code[i]);
+        }
+
+        for (size_t n = 0; n < rewritten.size(); ++n) {
+            if (origin[n] < 0 || !isJump(rewritten[n].op))
+                continue;
+
+            const int oldTarget = std::clamp(origin[n] + 1 + rewritten[n].operand, 0, last);
+
+            int newTarget = oldToNew[oldTarget];
+            if (newTarget < 0) {
+                int j = oldTarget;
+                while (j <= last && oldToNew[j] < 0)
+                    ++j;
+
+                newTarget = j > last ? static_cast<int>(rewritten.size()) : oldToNew[j];
+            }
+
+            rewritten[n].operand = newTarget - static_cast<int>(n) - 1;
+        }
+
+        code = std::move(rewritten);
+    }
+}

--- a/src/LOICollectionA/frontend/ir/opt/passes/LICMPass.cpp
+++ b/src/LOICollectionA/frontend/ir/opt/passes/LICMPass.cpp
@@ -74,6 +74,17 @@ namespace LOICollection::frontend::ir::opt {
             case OpCode::TYPE_OF:
             case OpCode::HAS_VALUE:
             case OpCode::IS_NONE:
+            case OpCode::ADD_I:
+            case OpCode::SUB_I:
+            case OpCode::MUL_I:
+            case OpCode::MOD_I:
+            case OpCode::CMP_EQ_I:
+            case OpCode::CMP_NE_I:
+            case OpCode::CMP_GT_I:
+            case OpCode::CMP_LT_I:
+            case OpCode::CMP_GE_I:
+            case OpCode::CMP_LE_I:
+            case OpCode::NEG_I:
                 return true;
 
             case OpCode::LOAD_SLOT:

--- a/src/LOICollectionA/frontend/ir/opt/passes/LICMPass.h
+++ b/src/LOICollectionA/frontend/ir/opt/passes/LICMPass.h
@@ -16,9 +16,6 @@ namespace LOICollection::frontend::ir::opt {
         size_t run();
 
     private:
-        // `retarget` names which inserted instruction inherits the jumps that used
-        // to land on `at`, so a back edge keeps pointing at the loop header after
-        // the instruction it targeted is deleted.
         struct Edit {
             int at = 0;
             bool erase = false;

--- a/src/LOICollectionA/frontend/ir/opt/passes/LICMPass.h
+++ b/src/LOICollectionA/frontend/ir/opt/passes/LICMPass.h
@@ -1,0 +1,39 @@
+#pragma once
+
+#include <vector>
+
+#include "LOICollectionA/frontend/ir/ByteCode.h"
+
+#include "LOICollectionA/frontend/ir/opt/analysis/ControlFlowGraph.h"
+#include "LOICollectionA/frontend/ir/opt/analysis/LoopAnalysis.h"
+
+namespace LOICollection::frontend::ir::opt {
+    class LICMPass {
+    public:
+        explicit LICMPass(BytecodeChunk& chunk)
+        : mChunk(chunk) {}
+
+        size_t run();
+
+    private:
+        // `retarget` names which inserted instruction inherits the jumps that used
+        // to land on `at`, so a back edge keeps pointing at the loop header after
+        // the instruction it targeted is deleted.
+        struct Edit {
+            int at = 0;
+            bool erase = false;
+            int retarget = -1;
+            std::vector<Instruction> insert;
+        };
+
+        size_t hoist(const ControlFlowGraph& cfg, const NaturalLoop& loop);
+
+        std::vector<bool> writtenSlots(const ControlFlowGraph& cfg, const NaturalLoop& loop) const;
+
+        bool isHoistable(const Instruction& instr, const std::vector<bool>& written) const;
+
+        static void apply(std::vector<Instruction>& code, const std::vector<Edit>& edits);
+
+        BytecodeChunk& mChunk;
+    };
+}

--- a/src/LOICollectionA/frontend/ir/vm/VMExecArith.cpp
+++ b/src/LOICollectionA/frontend/ir/vm/VMExecArith.cpp
@@ -42,6 +42,14 @@ namespace LOICollection::frontend::ir {
         }
     }
 
+    std::optional<int> topInt(std::vector<ValueNode::ValueType>& stack, size_t back) {
+        if (stack.size() <= back)
+            return std::nullopt;
+        if (auto p = std::get_if<int>(&stack[stack.size() - 1 - back]))
+            return *p;
+        return std::nullopt;
+    }
+
     static std::optional<OpCode> arithmeticOp(std::string_view op) {
         if (op == "+") return OpCode::ADD;
         if (op == "-") return OpCode::SUB;
@@ -63,17 +71,17 @@ namespace LOICollection::frontend::ir {
     }
 
     ValueNode::ValueType VM::applyArithmetic(const ValueNode::ValueType& left, const ValueNode::ValueType& right, OpCode op, DiagnosticEngine& diagnostics, const SourceLocation& loc) {
-        const std::string token = std::string(opToken(op));
+        const std::string_view token = opToken(op);
 
         if (auto leftObj = std::get_if<ObjectRef>(&left)) {
-            if (ClassCall::getInstance().hasOperator((*leftObj)->className, token)) {
+            if (ClassCall::getInstance().hasOperator((*leftObj)->className, std::string(token))) {
                 auto result = ClassCall::getInstance().callOperator(
-                    (*leftObj)->className, token, left, right, diagnostics, loc
+                    (*leftObj)->className, std::string(token), left, right, diagnostics, loc
                 );
 
                 if (!result.has_value()) {
                     diagnostics.addError(loc,
-                        "Operator '" + token + "' failed for class '" + (*leftObj)->className +
+                        "Operator '" + std::string(token) + "' failed for class '" + (*leftObj)->className +
                         "': " + result.error().message());
                     return 0;
                 }
@@ -83,14 +91,14 @@ namespace LOICollection::frontend::ir {
         }
 
         if (auto rightObj = std::get_if<ObjectRef>(&right)) {
-            if (ClassCall::getInstance().hasOperator((*rightObj)->className, token)) {
+            if (ClassCall::getInstance().hasOperator((*rightObj)->className, std::string(token))) {
                 auto result = ClassCall::getInstance().callOperator(
-                    (*rightObj)->className, token, left, right, diagnostics, loc
+                    (*rightObj)->className, std::string(token), left, right, diagnostics, loc
                 );
 
                 if (!result.has_value()) {
                     diagnostics.addError(loc,
-                        "Operator '" + token + "' failed for class '" + (*rightObj)->className +
+                        "Operator '" + std::string(token) + "' failed for class '" + (*rightObj)->className +
                         "': " + result.error().message());
                     return 0;
                 }
@@ -157,7 +165,7 @@ namespace LOICollection::frontend::ir {
                         diagnostics.addError(loc, "Modulo requires integral types");
                         return 0;
                     default:
-                        diagnostics.addError(loc, "Unknown arithmetic op: " + token);
+                        diagnostics.addError(loc, "Unknown arithmetic op: " + std::string(token));
                         return 0;
                 }
             } else {
@@ -222,17 +230,17 @@ namespace LOICollection::frontend::ir {
     }
 
     bool VM::applyComparison(const ValueNode::ValueType& left, const ValueNode::ValueType& right, OpCode op, DiagnosticEngine& diagnostics, const SourceLocation& loc) {
-        const std::string token = std::string(opToken(op));
+        const std::string_view token = opToken(op);
 
         if (auto leftObj = std::get_if<ObjectRef>(&left)) {
-            if (ClassCall::getInstance().hasOperator((*leftObj)->className, token)) {
+            if (ClassCall::getInstance().hasOperator((*leftObj)->className, std::string(token))) {
                 auto result = ClassCall::getInstance().callOperator(
-                    (*leftObj)->className, token, left, right, diagnostics, loc
+                    (*leftObj)->className, std::string(token), left, right, diagnostics, loc
                 );
 
                 if (!result.has_value()) {
                     diagnostics.addError(loc,
-                        "Operator '" + token + "' failed for class '" + (*leftObj)->className +
+                        "Operator '" + std::string(token) + "' failed for class '" + (*leftObj)->className +
                         "': " + result.error().message());
                     return false;
                 }
@@ -242,14 +250,14 @@ namespace LOICollection::frontend::ir {
         }
 
         if (auto rightObj = std::get_if<ObjectRef>(&right)) {
-            if (ClassCall::getInstance().hasOperator((*rightObj)->className, token)) {
+            if (ClassCall::getInstance().hasOperator((*rightObj)->className, std::string(token))) {
                 auto result = ClassCall::getInstance().callOperator(
-                    (*rightObj)->className, token, left, right, diagnostics, loc
+                    (*rightObj)->className, std::string(token), left, right, diagnostics, loc
                 );
 
                 if (!result.has_value()) {
                     diagnostics.addError(loc,
-                        "Operator '" + token + "' failed for class '" + (*rightObj)->className +
+                        "Operator '" + std::string(token) + "' failed for class '" + (*rightObj)->className +
                         "': " + result.error().message());
                     return false;
                 }
@@ -283,7 +291,7 @@ namespace LOICollection::frontend::ir {
                     default: break;
                 }
 
-                diagnostics.addError(loc, "Unknown comparison op: " + token);
+                diagnostics.addError(loc, "Unknown comparison op: " + std::string(token));
                 return false;
             } else if constexpr (
                 (std::is_same_v<T, ObjectRef> && std::is_same_v<U, ObjectRef>) ||
@@ -296,7 +304,7 @@ namespace LOICollection::frontend::ir {
                     default: break;
                 }
 
-                diagnostics.addError(loc, "Unknown comparison op: " + token);
+                diagnostics.addError(loc, "Unknown comparison op: " + std::string(token));
                 return false;
             } else if constexpr (std::is_same_v<T, U>) {
                 auto cmp = l <=> r;
@@ -311,7 +319,7 @@ namespace LOICollection::frontend::ir {
                     default: break;
                 }
 
-                diagnostics.addError(loc, "Unknown comparison op: " + token);
+                diagnostics.addError(loc, "Unknown comparison op: " + std::string(token));
                 return false;
             } else {
                 diagnostics.addError(loc, "Type mismatch in comparison");
@@ -331,27 +339,56 @@ namespace LOICollection::frontend::ir {
     void VM::execArithmetic(ExecArgs& s) {
         const auto& instr = s.instr;
         switch (instr.op) {
-            case OpCode::ADD: {
-                    auto r = this->pop();
-                    auto l = this->pop();
-
-                    auto result = VM::applyArithmetic(l, r, instr.op, this->diagnostics, this->currentLoc);
-
-                    if (std::holds_alternative<std::string>(result)) {
-                        if (const auto violation = this->mBudget->accountString(std::get<std::string>(result).size());
-                            violation != sandbox::SandboxBudget::Violation::None) {
-                            this->failBudget(violation, "String size budget exhausted");
+            case OpCode::ADD: case OpCode::SUB: case OpCode::MUL: case OpCode::MOD: {
+                auto r = topInt(this->stack, 0);
+                auto l = topInt(this->stack, 1);
+                if (l && r) {
+                    this->stack.pop_back();
+                    this->stack.pop_back();
+                    long long res = 0;
+                    switch (instr.op) {
+                        case OpCode::ADD: res = static_cast<long long>(*l) + *r; break;
+                        case OpCode::SUB: res = static_cast<long long>(*l) - *r; break;
+                        case OpCode::MUL: res = static_cast<long long>(*l) * *r; break;
+                        case OpCode::MOD:
+                            if (*r == 0) {
+                                this->diagnostics.addError(this->currentLoc, "Modulo by zero");
+                                this->push(0);
+                                break;
+                            }
+                            res = static_cast<long long>(*l) % *r;
+                            break;
+                        default: break;
+                    }
+                    if (instr.op != OpCode::MOD) {
+                        if (res < std::numeric_limits<int>::min() || res > std::numeric_limits<int>::max()) {
+                            this->diagnostics.addError(this->currentLoc,
+                                instr.op == OpCode::ADD ? "Integer overflow in addition"
+                                : instr.op == OpCode::SUB ? "Integer overflow in subtraction"
+                                : "Integer overflow in multiplication");
+                            this->push(0);
                             break;
                         }
                     }
-
-                    this->push(std::move(result));
+                    this->push(static_cast<int>(res));
+                    break;
+                }
+                auto rr = this->pop();
+                auto ll = this->pop();
+                auto result = VM::applyArithmetic(ll, rr, instr.op, this->diagnostics, this->currentLoc);
+                if (std::holds_alternative<std::string>(result)) {
+                    if (const auto violation = this->mBudget->accountString(std::get<std::string>(result).size());
+                        violation != sandbox::SandboxBudget::Violation::None) {
+                        this->failBudget(violation, "String size budget exhausted");
+                        break;
+                    }
+                }
+                this->push(std::move(result));
             } break;
-            case OpCode::SUB: case OpCode::MUL: case OpCode::DIV: case OpCode::MOD: case OpCode::POW: {
-                    auto r = this->pop();
-                    auto l = this->pop();
-
-                    this->push(VM::applyArithmetic(l, r, instr.op, this->diagnostics, this->currentLoc));
+            case OpCode::DIV: case OpCode::POW: {
+                auto rr = this->pop();
+                auto ll = this->pop();
+                this->push(VM::applyArithmetic(ll, rr, instr.op, this->diagnostics, this->currentLoc));
             } break;
             default: break;
         }
@@ -359,10 +396,31 @@ namespace LOICollection::frontend::ir {
 
     void VM::execComparison(ExecArgs& s) {
         const auto& instr = s.instr;
-        auto r = this->pop();
-        auto l = this->pop();
-
-        this->push(VM::applyComparison(l, r, instr.op, this->diagnostics, this->currentLoc));
+        auto r = topInt(this->stack, 0);
+        auto l = topInt(this->stack, 1);
+        if (l && r) {
+            this->stack.pop_back();
+            this->stack.pop_back();
+            bool b = false;
+            switch (instr.op) {
+                case OpCode::CMP_EQ: b = *l == *r; break;
+                case OpCode::CMP_NE: b = *l != *r; break;
+                case OpCode::CMP_GT: b = *l > *r; break;
+                case OpCode::CMP_LT: b = *l < *r; break;
+                case OpCode::CMP_GE: b = *l >= *r; break;
+                case OpCode::CMP_LE: b = *l <= *r; break;
+                default:
+                    this->stack.push_back(*l);
+                    this->stack.push_back(*r);
+                    this->push(VM::applyComparison(ValueNode::ValueType(*l), ValueNode::ValueType(*r), instr.op, this->diagnostics, this->currentLoc));
+                    return;
+            }
+            this->push(b);
+            return;
+        }
+        auto rr = this->pop();
+        auto ll = this->pop();
+        this->push(VM::applyComparison(ll, rr, instr.op, this->diagnostics, this->currentLoc));
     }
 
     void VM::execLogic(ExecArgs& s) {
@@ -381,9 +439,18 @@ namespace LOICollection::frontend::ir {
                     this->push(VM::valueToBool(l) || VM::valueToBool(r));
             } break;
             case OpCode::NEG: {
-                    auto v = this->pop();
-
-                    this->push(VM::applyUnary(v, instr.op, this->diagnostics, this->currentLoc));
+                if (!this->stack.empty() && std::holds_alternative<int>(this->stack.back())) {
+                    const int v = std::get<int>(this->stack.back());
+                    if (v == std::numeric_limits<int>::min()) {
+                        this->diagnostics.addError(this->currentLoc, "Integer overflow in unary negation");
+                        this->stack.back() = 0;
+                        break;
+                    }
+                    this->stack.back() = -v;
+                    break;
+                }
+                auto v = this->pop();
+                this->push(VM::applyUnary(v, instr.op, this->diagnostics, this->currentLoc));
             } break;
             case OpCode::NOT: {
                     auto v = this->pop();

--- a/src/LOICollectionA/frontend/ir/vm/VMExecArith.cpp
+++ b/src/LOICollectionA/frontend/ir/vm/VMExecArith.cpp
@@ -22,7 +22,25 @@
 
 namespace LOICollection::frontend::ir {
 
+    static OpCode genericOp(OpCode op) {
+        switch (op) {
+            case OpCode::ADD_I: return OpCode::ADD;
+            case OpCode::SUB_I: return OpCode::SUB;
+            case OpCode::MUL_I: return OpCode::MUL;
+            case OpCode::MOD_I: return OpCode::MOD;
+            case OpCode::CMP_EQ_I: return OpCode::CMP_EQ;
+            case OpCode::CMP_NE_I: return OpCode::CMP_NE;
+            case OpCode::CMP_GT_I: return OpCode::CMP_GT;
+            case OpCode::CMP_LT_I: return OpCode::CMP_LT;
+            case OpCode::CMP_GE_I: return OpCode::CMP_GE;
+            case OpCode::CMP_LE_I: return OpCode::CMP_LE;
+            case OpCode::NEG_I: return OpCode::NEG;
+            default: return op;
+        }
+    }
+
     static std::string_view opToken(OpCode op) {
+        op = genericOp(op);
         switch (op) {
             case OpCode::ADD: return "+";
             case OpCode::SUB: return "-";
@@ -71,6 +89,7 @@ namespace LOICollection::frontend::ir {
     }
 
     ValueNode::ValueType VM::applyArithmetic(const ValueNode::ValueType& left, const ValueNode::ValueType& right, OpCode op, DiagnosticEngine& diagnostics, const SourceLocation& loc) {
+        op = genericOp(op);
         const std::string_view token = opToken(op);
 
         if (auto leftObj = std::get_if<ObjectRef>(&left)) {
@@ -186,13 +205,14 @@ namespace LOICollection::frontend::ir {
     }
 
     ValueNode::ValueType VM::applyUnary(const ValueNode::ValueType& operand, OpCode op, DiagnosticEngine& diagnostics, const SourceLocation& loc) {
+        op = genericOp(op);
         return std::visit([&diagnostics, &loc, op](auto&& arg) -> ValueNode::ValueType {
             using T = std::decay_t<decltype(arg)>;
 
             if constexpr (std::is_arithmetic_v<T>) {
                 switch (op) {
                     case OpCode::NEG:
-                        if constexpr (std::is_integral_v<T>) {
+                        if constexpr (std::is_integral_v<T> && !std::is_same_v<T, bool>) {
                             if (arg == std::numeric_limits<int>::min()) {
                                 diagnostics.addError(loc, "Integer overflow in unary negation");
                                 return 0;
@@ -230,6 +250,7 @@ namespace LOICollection::frontend::ir {
     }
 
     bool VM::applyComparison(const ValueNode::ValueType& left, const ValueNode::ValueType& right, OpCode op, DiagnosticEngine& diagnostics, const SourceLocation& loc) {
+        op = genericOp(op);
         const std::string_view token = opToken(op);
 
         if (auto leftObj = std::get_if<ObjectRef>(&left)) {
@@ -339,6 +360,49 @@ namespace LOICollection::frontend::ir {
     void VM::execArithmetic(ExecArgs& s) {
         const auto& instr = s.instr;
         switch (instr.op) {
+            case OpCode::ADD_I: case OpCode::SUB_I: case OpCode::MUL_I: case OpCode::MOD_I: {
+                if (this->stack.size() < 2 || !std::holds_alternative<int>(this->stack.back()) ||
+                    !std::holds_alternative<int>(this->stack[this->stack.size() - 2])) {
+                    auto rr = this->pop();
+                    auto ll = this->pop();
+                    this->push(VM::applyArithmetic(ll, rr, genericOp(instr.op), this->diagnostics, this->currentLoc));
+                    break;
+                }
+
+                const int r = std::get<int>(this->stack.back());
+                this->stack.pop_back();
+                const int l = std::get<int>(this->stack.back());
+                this->stack.pop_back();
+
+                if (instr.op == OpCode::MOD_I) {
+                    if (r == 0) {
+                        this->diagnostics.addError(this->currentLoc, "Modulo by zero");
+                        this->push(0);
+                        break;
+                    }
+                    this->push(l % r);
+                    break;
+                }
+
+                long long res = 0;
+                switch (instr.op) {
+                    case OpCode::ADD_I: res = static_cast<long long>(l) + r; break;
+                    case OpCode::SUB_I: res = static_cast<long long>(l) - r; break;
+                    case OpCode::MUL_I: res = static_cast<long long>(l) * r; break;
+                    default: break;
+                }
+
+                if (res < std::numeric_limits<int>::min() || res > std::numeric_limits<int>::max()) {
+                    this->diagnostics.addError(this->currentLoc,
+                        instr.op == OpCode::ADD_I ? "Integer overflow in addition"
+                        : instr.op == OpCode::SUB_I ? "Integer overflow in subtraction"
+                        : "Integer overflow in multiplication");
+                    this->push(0);
+                    break;
+                }
+
+                this->push(static_cast<int>(res));
+            } break;
             case OpCode::ADD: case OpCode::SUB: case OpCode::MUL: case OpCode::MOD: {
                 auto r = topInt(this->stack, 0);
                 auto l = topInt(this->stack, 1);
@@ -396,6 +460,40 @@ namespace LOICollection::frontend::ir {
 
     void VM::execComparison(ExecArgs& s) {
         const auto& instr = s.instr;
+
+        switch (instr.op) {
+            case OpCode::CMP_EQ_I: case OpCode::CMP_NE_I: case OpCode::CMP_GT_I:
+            case OpCode::CMP_LT_I: case OpCode::CMP_GE_I: case OpCode::CMP_LE_I: {
+                if (this->stack.size() < 2 || !std::holds_alternative<int>(this->stack.back()) ||
+                    !std::holds_alternative<int>(this->stack[this->stack.size() - 2])) {
+                    auto rr = this->pop();
+                    auto ll = this->pop();
+                    this->push(VM::applyComparison(ll, rr, genericOp(instr.op), this->diagnostics, this->currentLoc));
+                    return;
+                }
+
+                const int r = std::get<int>(this->stack.back());
+                this->stack.pop_back();
+                const int l = std::get<int>(this->stack.back());
+                this->stack.pop_back();
+
+                bool b = false;
+                switch (instr.op) {
+                    case OpCode::CMP_EQ_I: b = l == r; break;
+                    case OpCode::CMP_NE_I: b = l != r; break;
+                    case OpCode::CMP_GT_I: b = l > r; break;
+                    case OpCode::CMP_LT_I: b = l < r; break;
+                    case OpCode::CMP_GE_I: b = l >= r; break;
+                    case OpCode::CMP_LE_I: b = l <= r; break;
+                    default: break;
+                }
+
+                this->push(b);
+                return;
+            }
+            default: break;
+        }
+
         auto r = topInt(this->stack, 0);
         auto l = topInt(this->stack, 1);
         if (l && r) {
@@ -438,8 +536,13 @@ namespace LOICollection::frontend::ir {
 
                     this->push(VM::valueToBool(l) || VM::valueToBool(r));
             } break;
-            case OpCode::NEG: {
-                if (!this->stack.empty() && std::holds_alternative<int>(this->stack.back())) {
+            case OpCode::NEG_I: {
+                    if (this->stack.empty() || !std::holds_alternative<int>(this->stack.back())) {
+                        auto v = this->pop();
+                        this->push(VM::applyUnary(v, OpCode::NEG, this->diagnostics, this->currentLoc));
+                        break;
+                    }
+
                     const int v = std::get<int>(this->stack.back());
                     if (v == std::numeric_limits<int>::min()) {
                         this->diagnostics.addError(this->currentLoc, "Integer overflow in unary negation");
@@ -447,10 +550,20 @@ namespace LOICollection::frontend::ir {
                         break;
                     }
                     this->stack.back() = -v;
-                    break;
-                }
-                auto v = this->pop();
-                this->push(VM::applyUnary(v, instr.op, this->diagnostics, this->currentLoc));
+            } break;
+            case OpCode::NEG: {
+                    if (!this->stack.empty() && std::holds_alternative<int>(this->stack.back())) {
+                        const int v = std::get<int>(this->stack.back());
+                        if (v == std::numeric_limits<int>::min()) {
+                            this->diagnostics.addError(this->currentLoc, "Integer overflow in unary negation");
+                            this->stack.back() = 0;
+                            break;
+                        }
+                        this->stack.back() = -v;
+                        break;
+                    }
+                    auto v = this->pop();
+                    this->push(VM::applyUnary(v, instr.op, this->diagnostics, this->currentLoc));
             } break;
             case OpCode::NOT: {
                     auto v = this->pop();

--- a/src/LOICollectionA/frontend/ir/vm/VMExecArith.cpp
+++ b/src/LOICollectionA/frontend/ir/vm/VMExecArith.cpp
@@ -525,24 +525,34 @@ namespace LOICollection::frontend::ir {
         const auto& instr = s.instr;
         switch (instr.op) {
             case OpCode::LOGIC_AND: {
-                    auto r = this->pop();
-                    auto l = this->pop();
+                auto r = this->pop();
+                auto l = this->pop();
 
-                    this->push(VM::valueToBool(l) && VM::valueToBool(r));
+                this->push(VM::valueToBool(l) && VM::valueToBool(r));
             } break;
             case OpCode::LOGIC_OR: {
-                    auto r = this->pop();
-                    auto l = this->pop();
+                auto r = this->pop();
+                auto l = this->pop();
 
-                    this->push(VM::valueToBool(l) || VM::valueToBool(r));
+                this->push(VM::valueToBool(l) || VM::valueToBool(r));
             } break;
             case OpCode::NEG_I: {
-                    if (this->stack.empty() || !std::holds_alternative<int>(this->stack.back())) {
-                        auto v = this->pop();
-                        this->push(VM::applyUnary(v, OpCode::NEG, this->diagnostics, this->currentLoc));
-                        break;
-                    }
+                if (this->stack.empty() || !std::holds_alternative<int>(this->stack.back())) {
+                    auto v = this->pop();
+                    this->push(VM::applyUnary(v, OpCode::NEG, this->diagnostics, this->currentLoc));
+                    break;
+                }
 
+                const int v = std::get<int>(this->stack.back());
+                if (v == std::numeric_limits<int>::min()) {
+                    this->diagnostics.addError(this->currentLoc, "Integer overflow in unary negation");
+                    this->stack.back() = 0;
+                    break;
+                }
+                this->stack.back() = -v;
+            } break;
+            case OpCode::NEG: {
+                if (!this->stack.empty() && std::holds_alternative<int>(this->stack.back())) {
                     const int v = std::get<int>(this->stack.back());
                     if (v == std::numeric_limits<int>::min()) {
                         this->diagnostics.addError(this->currentLoc, "Integer overflow in unary negation");
@@ -550,25 +560,15 @@ namespace LOICollection::frontend::ir {
                         break;
                     }
                     this->stack.back() = -v;
-            } break;
-            case OpCode::NEG: {
-                    if (!this->stack.empty() && std::holds_alternative<int>(this->stack.back())) {
-                        const int v = std::get<int>(this->stack.back());
-                        if (v == std::numeric_limits<int>::min()) {
-                            this->diagnostics.addError(this->currentLoc, "Integer overflow in unary negation");
-                            this->stack.back() = 0;
-                            break;
-                        }
-                        this->stack.back() = -v;
-                        break;
-                    }
-                    auto v = this->pop();
-                    this->push(VM::applyUnary(v, instr.op, this->diagnostics, this->currentLoc));
+                    break;
+                }
+                auto v = this->pop();
+                this->push(VM::applyUnary(v, instr.op, this->diagnostics, this->currentLoc));
             } break;
             case OpCode::NOT: {
-                    auto v = this->pop();
+                auto v = this->pop();
 
-                    this->push(!VM::valueToBool(v));
+                this->push(!VM::valueToBool(v));
             } break;
             default: break;
         }

--- a/src/LOICollectionA/frontend/ir/vm/VMExecArith.cpp
+++ b/src/LOICollectionA/frontend/ir/vm/VMExecArith.cpp
@@ -1,16 +1,20 @@
+#include <algorithm>
+#include <chrono>
 #include <cmath>
 #include <cctype>
-#include <chrono>
 #include <limits>
+#include <optional>
 #include <ranges>
 #include <string>
+#include <string_view>
 #include <vector>
-#include <algorithm>
 
 #include <ll/api/Expected.h>
 
 #include "LOICollectionA/frontend/Callback.h"
 #include "LOICollectionA/frontend/Unicode.h"
+
+#include "LOICollectionA/frontend/ir/OpCode.h"
 
 #include "LOICollectionA/utils/core/MathUtils.h"
 
@@ -18,16 +22,58 @@
 
 namespace LOICollection::frontend::ir {
 
-    ValueNode::ValueType VM::applyArithmetic(const ValueNode::ValueType& left, const ValueNode::ValueType& right, const std::string& op, DiagnosticEngine& diagnostics, const SourceLocation& loc) {
+    static std::string_view opToken(OpCode op) {
+        switch (op) {
+            case OpCode::ADD: return "+";
+            case OpCode::SUB: return "-";
+            case OpCode::MUL: return "*";
+            case OpCode::DIV: return "/";
+            case OpCode::MOD: return "%";
+            case OpCode::POW: return "^";
+            case OpCode::CMP_EQ: return "==";
+            case OpCode::CMP_NE: return "!=";
+            case OpCode::CMP_GT: return ">";
+            case OpCode::CMP_LT: return "<";
+            case OpCode::CMP_GE: return ">=";
+            case OpCode::CMP_LE: return "<=";
+            case OpCode::NEG: return "-";
+            case OpCode::NOT: return "!";
+            default: return "?";
+        }
+    }
+
+    static std::optional<OpCode> arithmeticOp(std::string_view op) {
+        if (op == "+") return OpCode::ADD;
+        if (op == "-") return OpCode::SUB;
+        if (op == "*") return OpCode::MUL;
+        if (op == "/") return OpCode::DIV;
+        if (op == "%") return OpCode::MOD;
+        if (op == "^") return OpCode::POW;
+        return std::nullopt;
+    }
+
+    static std::optional<OpCode> comparisonOp(std::string_view op) {
+        if (op == "==") return OpCode::CMP_EQ;
+        if (op == "!=") return OpCode::CMP_NE;
+        if (op == ">") return OpCode::CMP_GT;
+        if (op == "<") return OpCode::CMP_LT;
+        if (op == ">=") return OpCode::CMP_GE;
+        if (op == "<=") return OpCode::CMP_LE;
+        return std::nullopt;
+    }
+
+    ValueNode::ValueType VM::applyArithmetic(const ValueNode::ValueType& left, const ValueNode::ValueType& right, OpCode op, DiagnosticEngine& diagnostics, const SourceLocation& loc) {
+        const std::string token = std::string(opToken(op));
+
         if (auto leftObj = std::get_if<ObjectRef>(&left)) {
-            if (ClassCall::getInstance().hasOperator((*leftObj)->className, op)) {
+            if (ClassCall::getInstance().hasOperator((*leftObj)->className, token)) {
                 auto result = ClassCall::getInstance().callOperator(
-                    (*leftObj)->className, op, left, right, diagnostics, loc
+                    (*leftObj)->className, token, left, right, diagnostics, loc
                 );
 
                 if (!result.has_value()) {
                     diagnostics.addError(loc,
-                        "Operator '" + op + "' failed for class '" + (*leftObj)->className +
+                        "Operator '" + token + "' failed for class '" + (*leftObj)->className +
                         "': " + result.error().message());
                     return 0;
                 }
@@ -35,18 +81,16 @@ namespace LOICollection::frontend::ir {
                 return result.value();
             }
         }
-
-        
 
         if (auto rightObj = std::get_if<ObjectRef>(&right)) {
-            if (ClassCall::getInstance().hasOperator((*rightObj)->className, op)) {
+            if (ClassCall::getInstance().hasOperator((*rightObj)->className, token)) {
                 auto result = ClassCall::getInstance().callOperator(
-                    (*rightObj)->className, op, left, right, diagnostics, loc
+                    (*rightObj)->className, token, left, right, diagnostics, loc
                 );
 
                 if (!result.has_value()) {
                     diagnostics.addError(loc,
-                        "Operator '" + op + "' failed for class '" + (*rightObj)->className +
+                        "Operator '" + token + "' failed for class '" + (*rightObj)->className +
                         "': " + result.error().message());
                     return 0;
                 }
@@ -55,7 +99,7 @@ namespace LOICollection::frontend::ir {
             }
         }
 
-        return std::visit([&op, &diagnostics, &loc](auto&& l, auto&& r) -> ValueNode::ValueType {
+        return std::visit([&token, &diagnostics, &loc, op](auto&& l, auto&& r) -> ValueNode::ValueType {
             using T = std::decay_t<decltype(l)>;
             using U = std::decay_t<decltype(r)>;
 
@@ -67,59 +111,57 @@ namespace LOICollection::frontend::ir {
                 auto dl = static_cast<double>(l);
                 auto dr = static_cast<double>(r);
 
-                if (op == "+") {
-                    if constexpr (std::is_integral_v<T> && std::is_integral_v<U>) {
-                        long long result = static_cast<long long>(l) + static_cast<long long>(r);
-                        if (result < std::numeric_limits<int>::min() || result > std::numeric_limits<int>::max()) {
-                            diagnostics.addError(loc, "Integer overflow in addition");
-                            return 0;
+                switch (op) {
+                    case OpCode::ADD:
+                        if constexpr (std::is_integral_v<T> && std::is_integral_v<U>) {
+                            long long result = static_cast<long long>(l) + static_cast<long long>(r);
+                            if (result < std::numeric_limits<int>::min() || result > std::numeric_limits<int>::max()) {
+                                diagnostics.addError(loc, "Integer overflow in addition");
+                                return 0;
+                            }
+                            return static_cast<int>(result);
                         }
-                        return static_cast<int>(result);
-                    }
-                    return static_cast<float>(dl + dr);
-                }
-                if (op == "-") {
-                    if constexpr (std::is_integral_v<T> && std::is_integral_v<U>) {
-                        long long result = static_cast<long long>(l) - static_cast<long long>(r);
-                        if (result < std::numeric_limits<int>::min() || result > std::numeric_limits<int>::max()) {
-                            diagnostics.addError(loc, "Integer overflow in subtraction");
-                            return 0;
+                        return static_cast<float>(dl + dr);
+                    case OpCode::SUB:
+                        if constexpr (std::is_integral_v<T> && std::is_integral_v<U>) {
+                            long long result = static_cast<long long>(l) - static_cast<long long>(r);
+                            if (result < std::numeric_limits<int>::min() || result > std::numeric_limits<int>::max()) {
+                                diagnostics.addError(loc, "Integer overflow in subtraction");
+                                return 0;
+                            }
+                            return static_cast<int>(result);
                         }
-                        return static_cast<int>(result);
-                    }
-                    return static_cast<float>(dl - dr);
-                }
-                if (op == "*") {
-                    if constexpr (std::is_integral_v<T> && std::is_integral_v<U>) {
-                        long long result = static_cast<long long>(l) * static_cast<long long>(r);
-                        if (result < std::numeric_limits<int>::min() || result > std::numeric_limits<int>::max()) {
-                            diagnostics.addError(loc, "Integer overflow in multiplication");
-                            return 0;
+                        return static_cast<float>(dl - dr);
+                    case OpCode::MUL:
+                        if constexpr (std::is_integral_v<T> && std::is_integral_v<U>) {
+                            long long result = static_cast<long long>(l) * static_cast<long long>(r);
+                            if (result < std::numeric_limits<int>::min() || result > std::numeric_limits<int>::max()) {
+                                diagnostics.addError(loc, "Integer overflow in multiplication");
+                                return 0;
+                            }
+                            return static_cast<int>(result);
                         }
-                        return static_cast<int>(result);
-                    }
-                    return static_cast<float>(dl * dr);
-                }
-                if (op == "/") return static_cast<float>(dl / dr);
-                if (op == "^") return static_cast<float>(MathUtils::pow(dl, dr));
-                if (op == "%") {
-                    if constexpr (std::is_integral_v<T> && std::is_integral_v<U>) {
-                        auto divisor = static_cast<long long>(r);
-                        if (divisor == 0) {
-                            diagnostics.addError(loc, "Modulo by zero");
-                            return 0;
+                        return static_cast<float>(dl * dr);
+                    case OpCode::DIV: return static_cast<float>(dl / dr);
+                    case OpCode::POW: return static_cast<float>(MathUtils::pow(dl, dr));
+                    case OpCode::MOD:
+                        if constexpr (std::is_integral_v<T> && std::is_integral_v<U>) {
+                            auto divisor = static_cast<long long>(r);
+                            if (divisor == 0) {
+                                diagnostics.addError(loc, "Modulo by zero");
+                                return 0;
+                            }
+                            return static_cast<int>(static_cast<long long>(l) % divisor);
                         }
-                        return static_cast<int>(static_cast<long long>(l) % divisor);
-                    }
-                        
-                    diagnostics.addError(loc, "Modulo requires integral types");
-                    return 0;
-                }
 
-                diagnostics.addError(loc, "Unknown arithmetic op: " + op);
-                return 0;
+                        diagnostics.addError(loc, "Modulo requires integral types");
+                        return 0;
+                    default:
+                        diagnostics.addError(loc, "Unknown arithmetic op: " + token);
+                        return 0;
+                }
             } else {
-                if (op == "+") return VM::valueToString(l) + VM::valueToString(r);
+                if (op == OpCode::ADD) return VM::valueToString(l) + VM::valueToString(r);
 
                 diagnostics.addError(loc, "Type mismatch in arithmetic");
                 return 0;
@@ -127,39 +169,70 @@ namespace LOICollection::frontend::ir {
         }, left, right);
     }
 
-    ValueNode::ValueType VM::applyUnary(const ValueNode::ValueType& operand, const std::string& op, DiagnosticEngine& diagnostics, const SourceLocation& loc) {
-        return std::visit([&op, &diagnostics, &loc](auto&& arg) -> ValueNode::ValueType {
+    ValueNode::ValueType VM::applyArithmetic(const ValueNode::ValueType& left, const ValueNode::ValueType& right, const std::string& op, DiagnosticEngine& diagnostics, const SourceLocation& loc) {
+        if (auto oc = arithmeticOp(op))
+            return applyArithmetic(left, right, *oc, diagnostics, loc);
+
+        diagnostics.addError(loc, "Unknown arithmetic op: " + op);
+        return 0;
+    }
+
+    ValueNode::ValueType VM::applyUnary(const ValueNode::ValueType& operand, OpCode op, DiagnosticEngine& diagnostics, const SourceLocation& loc) {
+        return std::visit([&diagnostics, &loc, op](auto&& arg) -> ValueNode::ValueType {
             using T = std::decay_t<decltype(arg)>;
 
             if constexpr (std::is_arithmetic_v<T>) {
-                if (op == "+") return arg;
-                if (op == "-") {
-                    if constexpr (std::is_integral_v<T>) {
-                        if (arg == std::numeric_limits<int>::min()) {
-                            diagnostics.addError(loc, "Integer overflow in unary negation");
-                            return 0;
+                switch (op) {
+                    case OpCode::NEG:
+                        if constexpr (std::is_integral_v<T>) {
+                            if (arg == std::numeric_limits<int>::min()) {
+                                diagnostics.addError(loc, "Integer overflow in unary negation");
+                                return 0;
+                            }
                         }
-                    }
-                    return -arg;
+                        return -arg;
+                    case OpCode::NOT:
+                        return !VM::valueToBool(arg);
+                    default: break;
                 }
             }
-            if (op == "!") return !VM::valueToBool(arg);
 
-            diagnostics.addError(loc, "Unknown unary op: " + op);
+            if (op == OpCode::NOT) return !VM::valueToBool(arg);
+
+            diagnostics.addError(loc, "Unknown unary op: " + std::string(opToken(op)));
             return 0;
         }, operand);
     }
 
-    bool VM::applyComparison(const ValueNode::ValueType& left, const ValueNode::ValueType& right, const std::string& op, DiagnosticEngine& diagnostics, const SourceLocation& loc) {
+    ValueNode::ValueType VM::applyUnary(const ValueNode::ValueType& operand, const std::string& op, DiagnosticEngine& diagnostics, const SourceLocation& loc) {
+        if (op == "+")
+            return std::visit([&diagnostics, &loc](auto&& arg) -> ValueNode::ValueType {
+                if constexpr (std::is_arithmetic_v<std::decay_t<decltype(arg)>>)
+                    return ValueNode::ValueType(arg);
+
+                diagnostics.addError(loc, "Unknown unary op: +");
+                return 0;
+            }, operand);
+
+        if (op == "-") return applyUnary(operand, OpCode::NEG, diagnostics, loc);
+        if (op == "!") return applyUnary(operand, OpCode::NOT, diagnostics, loc);
+
+        diagnostics.addError(loc, "Unknown unary op: " + op);
+        return 0;
+    }
+
+    bool VM::applyComparison(const ValueNode::ValueType& left, const ValueNode::ValueType& right, OpCode op, DiagnosticEngine& diagnostics, const SourceLocation& loc) {
+        const std::string token = std::string(opToken(op));
+
         if (auto leftObj = std::get_if<ObjectRef>(&left)) {
-            if (ClassCall::getInstance().hasOperator((*leftObj)->className, op)) {
+            if (ClassCall::getInstance().hasOperator((*leftObj)->className, token)) {
                 auto result = ClassCall::getInstance().callOperator(
-                    (*leftObj)->className, op, left, right, diagnostics, loc
+                    (*leftObj)->className, token, left, right, diagnostics, loc
                 );
 
                 if (!result.has_value()) {
                     diagnostics.addError(loc,
-                        "Operator '" + op + "' failed for class '" + (*leftObj)->className +
+                        "Operator '" + token + "' failed for class '" + (*leftObj)->className +
                         "': " + result.error().message());
                     return false;
                 }
@@ -167,18 +240,16 @@ namespace LOICollection::frontend::ir {
                 return VM::valueToBool(result.value());
             }
         }
-
-        
 
         if (auto rightObj = std::get_if<ObjectRef>(&right)) {
-            if (ClassCall::getInstance().hasOperator((*rightObj)->className, op)) {
+            if (ClassCall::getInstance().hasOperator((*rightObj)->className, token)) {
                 auto result = ClassCall::getInstance().callOperator(
-                    (*rightObj)->className, op, left, right, diagnostics, loc
+                    (*rightObj)->className, token, left, right, diagnostics, loc
                 );
 
                 if (!result.has_value()) {
                     diagnostics.addError(loc,
-                        "Operator '" + op + "' failed for class '" + (*rightObj)->className +
+                        "Operator '" + token + "' failed for class '" + (*rightObj)->className +
                         "': " + result.error().message());
                     return false;
                 }
@@ -187,14 +258,14 @@ namespace LOICollection::frontend::ir {
             }
         }
 
-        return std::visit([&op, &diagnostics, &loc](auto&& l, auto&& r) -> bool {
+        return std::visit([&token, &diagnostics, &loc, op](auto&& l, auto&& r) -> bool {
             using T = std::decay_t<decltype(l)>;
             using U = std::decay_t<decltype(r)>;
 
             if constexpr (std::is_same_v<T, std::monostate> || std::is_same_v<U, std::monostate>) {
                 if constexpr (std::is_same_v<T, std::monostate> && std::is_same_v<U, std::monostate>) {
-                    if (op == "==") return true;
-                    if (op == "!=") return false;
+                    if (op == OpCode::CMP_EQ) return true;
+                    if (op == OpCode::CMP_NE) return false;
                 }
 
                 diagnostics.addError(loc, "Cannot compare an empty optional value");
@@ -202,42 +273,59 @@ namespace LOICollection::frontend::ir {
             } else if constexpr (std::is_arithmetic_v<T> && std::is_arithmetic_v<U>) {
                 auto cmp = static_cast<double>(l) <=> static_cast<double>(r);
 
-                if (op == "==") return cmp == 0;
-                if (op == "!=") return cmp != 0;
-                if (op == ">") return cmp > 0;
-                if (op == "<") return cmp < 0;
-                if (op == ">=") return cmp >= 0;
-                if (op == "<=") return cmp <= 0;
+                switch (op) {
+                    case OpCode::CMP_EQ: return cmp == 0;
+                    case OpCode::CMP_NE: return cmp != 0;
+                    case OpCode::CMP_GT: return cmp > 0;
+                    case OpCode::CMP_LT: return cmp < 0;
+                    case OpCode::CMP_GE: return cmp >= 0;
+                    case OpCode::CMP_LE: return cmp <= 0;
+                    default: break;
+                }
 
-                diagnostics.addError(loc, "Unknown comparison op: " + op);
+                diagnostics.addError(loc, "Unknown comparison op: " + token);
                 return false;
             } else if constexpr (
                 (std::is_same_v<T, ObjectRef> && std::is_same_v<U, ObjectRef>) ||
                 (std::is_same_v<T, FunctionRefPtr> && std::is_same_v<U, FunctionRefPtr>) ||
                 (std::is_same_v<T, ArrayRef> && std::is_same_v<U, ArrayRef>)
             ) {
-                if (op == "==") return l == r;
-                if (op == "!=") return l != r;
+                switch (op) {
+                    case OpCode::CMP_EQ: return l == r;
+                    case OpCode::CMP_NE: return l != r;
+                    default: break;
+                }
 
-                diagnostics.addError(loc, "Unknown comparison op: " + op);
+                diagnostics.addError(loc, "Unknown comparison op: " + token);
                 return false;
             } else if constexpr (std::is_same_v<T, U>) {
                 auto cmp = l <=> r;
 
-                if (op == "==") return cmp == 0;
-                if (op == "!=") return cmp != 0;
-                if (op == ">") return cmp > 0;
-                if (op == "<") return cmp < 0;
-                if (op == ">=") return cmp >= 0;
-                if (op == "<=") return cmp <= 0;
+                switch (op) {
+                    case OpCode::CMP_EQ: return cmp == 0;
+                    case OpCode::CMP_NE: return cmp != 0;
+                    case OpCode::CMP_GT: return cmp > 0;
+                    case OpCode::CMP_LT: return cmp < 0;
+                    case OpCode::CMP_GE: return cmp >= 0;
+                    case OpCode::CMP_LE: return cmp <= 0;
+                    default: break;
+                }
 
-                diagnostics.addError(loc, "Unknown comparison op: " + op);
+                diagnostics.addError(loc, "Unknown comparison op: " + token);
                 return false;
             } else {
                 diagnostics.addError(loc, "Type mismatch in comparison");
                 return false;
             }
         }, left, right);
+    }
+
+    bool VM::applyComparison(const ValueNode::ValueType& left, const ValueNode::ValueType& right, const std::string& op, DiagnosticEngine& diagnostics, const SourceLocation& loc) {
+        if (auto oc = comparisonOp(op))
+            return applyComparison(left, right, *oc, diagnostics, loc);
+
+        diagnostics.addError(loc, "Unknown comparison op: " + op);
+        return false;
     }
 
     void VM::execArithmetic(ExecArgs& s) {
@@ -247,7 +335,7 @@ namespace LOICollection::frontend::ir {
                     auto r = this->pop();
                     auto l = this->pop();
 
-                    auto result = VM::applyArithmetic(l, r, "+", this->diagnostics, this->currentLoc);
+                    auto result = VM::applyArithmetic(l, r, instr.op, this->diagnostics, this->currentLoc);
 
                     if (std::holds_alternative<std::string>(result)) {
                         if (const auto violation = this->mBudget->accountString(std::get<std::string>(result).size());
@@ -259,35 +347,11 @@ namespace LOICollection::frontend::ir {
 
                     this->push(std::move(result));
             } break;
-            case OpCode::SUB: {
+            case OpCode::SUB: case OpCode::MUL: case OpCode::DIV: case OpCode::MOD: case OpCode::POW: {
                     auto r = this->pop();
                     auto l = this->pop();
 
-                    this->push(VM::applyArithmetic(l, r, "-", this->diagnostics, this->currentLoc));
-            } break;
-            case OpCode::MUL: {
-                    auto r = this->pop();
-                    auto l = this->pop();
-
-                    this->push(VM::applyArithmetic(l, r, "*", this->diagnostics, this->currentLoc));
-            } break;
-            case OpCode::DIV: {
-                    auto r = this->pop();
-                    auto l = this->pop();
-
-                    this->push(VM::applyArithmetic(l, r, "/", this->diagnostics, this->currentLoc));
-            } break;
-            case OpCode::MOD: {
-                    auto r = this->pop();
-                    auto l = this->pop();
-
-                    this->push(VM::applyArithmetic(l, r, "%", this->diagnostics, this->currentLoc));
-            } break;
-            case OpCode::POW: {
-                    auto r = this->pop();
-                    auto l = this->pop();
-
-                    this->push(VM::applyArithmetic(l, r, "^", this->diagnostics, this->currentLoc));
+                    this->push(VM::applyArithmetic(l, r, instr.op, this->diagnostics, this->currentLoc));
             } break;
             default: break;
         }
@@ -295,45 +359,10 @@ namespace LOICollection::frontend::ir {
 
     void VM::execComparison(ExecArgs& s) {
         const auto& instr = s.instr;
-        switch (instr.op) {
-            case OpCode::CMP_EQ: {
-                    auto r = this->pop();
-                    auto l = this->pop();
+        auto r = this->pop();
+        auto l = this->pop();
 
-                    this->push(VM::applyComparison(l, r, "==", this->diagnostics, this->currentLoc));
-            } break;
-            case OpCode::CMP_NE: {
-                    auto r = this->pop();
-                    auto l = this->pop();
-
-                    this->push(VM::applyComparison(l, r, "!=", this->diagnostics, this->currentLoc));
-            } break;
-            case OpCode::CMP_GT: {
-                    auto r = this->pop();
-                    auto l = this->pop();
-
-                    this->push(VM::applyComparison(l, r, ">", this->diagnostics, this->currentLoc));
-            } break;
-            case OpCode::CMP_LT: {
-                    auto r = this->pop();
-                    auto l = this->pop();
-
-                    this->push(VM::applyComparison(l, r, "<", this->diagnostics, this->currentLoc));
-            } break;
-            case OpCode::CMP_GE: {
-                    auto r = this->pop();
-                    auto l = this->pop();
-
-                    this->push(VM::applyComparison(l, r, ">=", this->diagnostics, this->currentLoc));
-            } break;
-            case OpCode::CMP_LE: {
-                    auto r = this->pop();
-                    auto l = this->pop();
-
-                    this->push(VM::applyComparison(l, r, "<=", this->diagnostics, this->currentLoc));
-            } break;
-            default: break;
-        }
+        this->push(VM::applyComparison(l, r, instr.op, this->diagnostics, this->currentLoc));
     }
 
     void VM::execLogic(ExecArgs& s) {
@@ -354,7 +383,7 @@ namespace LOICollection::frontend::ir {
             case OpCode::NEG: {
                     auto v = this->pop();
 
-                    this->push(VM::applyUnary(v, "-", this->diagnostics, this->currentLoc));
+                    this->push(VM::applyUnary(v, instr.op, this->diagnostics, this->currentLoc));
             } break;
             case OpCode::NOT: {
                     auto v = this->pop();

--- a/src/LOICollectionA/frontend/ir/vm/VMExecCall.cpp
+++ b/src/LOICollectionA/frontend/ir/vm/VMExecCall.cpp
@@ -50,16 +50,12 @@ namespace LOICollection::frontend::ir {
                         break;
                     }
 
-                    std::vector<ValueNode::ValueType> args(meta.argCount);
-                    for (int i = 0; i < meta.argCount; ++i)
-                        args[meta.argCount - 1 - i] = this->pop();
-
                     Frame callee(*chunk.methodBodies[meta.bodyIndex]);
                     callee.hasThis = true;
                     callee.thisObj = receiver;
 
                     for (int i = 0; i < meta.argCount; ++i)
-                        callee.locals[i] = args[i];
+                        callee.locals[meta.argCount - 1 - i] = this->pop();
 
                     if (!this->pushFrame(std::move(callee)))
                         break;
@@ -98,16 +94,12 @@ namespace LOICollection::frontend::ir {
                         break;
                     }
 
-                    std::vector<ValueNode::ValueType> args(method.argCount);
-                    for (int i = 0; i < method.argCount; ++i)
-                        args[method.argCount - 1 - i] = this->pop();
-
                     Frame callee(*chunk.methodBodies[method.bodyIndex]);
                     callee.hasThis = true;
                     callee.thisObj = receiver;
 
                     for (int i = 0; i < method.argCount; ++i)
-                        callee.locals[i] = args[i];
+                        callee.locals[method.argCount - 1 - i] = this->pop();
 
                     if (!this->pushFrame(std::move(callee)))
                         break;
@@ -144,16 +136,13 @@ namespace LOICollection::frontend::ir {
                     }
 
                     const auto& method = chunk.methods[cls.methods[ordinal]];
-                    std::vector<ValueNode::ValueType> args(method.argCount);
-                    for (int i = 0; i < method.argCount; ++i)
-                        args[method.argCount - 1 - i] = this->pop();
 
                     Frame callee(*chunk.methodBodies[method.bodyIndex]);
                     callee.hasThis = true;
                     callee.thisObj = receiver;
 
                     for (int i = 0; i < method.argCount; ++i)
-                        callee.locals[i] = args[i];
+                        callee.locals[method.argCount - 1 - i] = this->pop();
 
                     if (!this->pushFrame(std::move(callee)))
                         break;
@@ -184,16 +173,12 @@ namespace LOICollection::frontend::ir {
                         break;
                     }
 
-                    std::vector<ValueNode::ValueType> args(ctor.argCount);
-                    for (int i = 0; i < ctor.argCount; ++i)
-                        args[ctor.argCount - 1 - i] = this->pop();
-
                     Frame callee(*chunk.methodBodies[ctor.bodyIndex]);
                     callee.hasThis = true;
                     callee.thisObj = receiver;
 
                     for (int i = 0; i < ctor.argCount; ++i)
-                        callee.locals[i] = args[i];
+                        callee.locals[ctor.argCount - 1 - i] = this->pop();
 
                     if (!this->pushFrame(std::move(callee)))
                         break;
@@ -331,10 +316,6 @@ namespace LOICollection::frontend::ir {
                         break;
                     }
 
-                    std::vector<ValueNode::ValueType> args(func->argCount);
-                    for (int i = 0; i < func->argCount; ++i)
-                        args[func->argCount - 1 - i] = this->pop();
-
                     Frame callee(*func->owner->methodBodies[func->bodyIndex]);
                     callee.hasThis = func->hasThis;
                     if (func->hasThis) {
@@ -356,7 +337,7 @@ namespace LOICollection::frontend::ir {
                     std::copy_n(func->captures.begin(), paramBase, callee.locals.begin());
 
                     for (int i = 0; i < func->argCount; ++i)
-                        callee.locals[paramBase + i] = args[i];
+                        callee.locals[paramBase + func->argCount - 1 - i] = this->pop();
 
                     if (!this->pushFrame(std::move(callee)))
                         break;

--- a/src/LOICollectionA/frontend/ir/vm/VMExecCall.cpp
+++ b/src/LOICollectionA/frontend/ir/vm/VMExecCall.cpp
@@ -35,157 +35,157 @@ namespace LOICollection::frontend::ir {
         const BytecodeChunk& chunk = s.chunk;
         switch (instr.op) {
             case OpCode::CALL_METHOD: {
-                    const auto& meta = chunk.methods[instr.operand];
+                const auto& meta = chunk.methods[instr.operand];
 
-                    auto receiver = this->pop();
-                    if (!std::holds_alternative<ObjectRef>(receiver)) {
-                        this->diagnostics.addError(this->currentLoc, "Method call target is not an object");
-                        break;
-                    }
+                auto receiver = this->pop();
+                if (!std::holds_alternative<ObjectRef>(receiver)) {
+                    this->diagnostics.addError(this->currentLoc, "Method call target is not an object");
+                    break;
+                }
 
-                    auto obj = std::get<ObjectRef>(receiver);
-                    if (!this->isDerived(chunk, obj->classIndex, meta.classIndex)) {
-                        this->diagnostics.addError(this->currentLoc,
-                            "Method '" + meta.name + "' does not belong to this object");
-                        break;
-                    }
+                auto obj = std::get<ObjectRef>(receiver);
+                if (!this->isDerived(chunk, obj->classIndex, meta.classIndex)) {
+                    this->diagnostics.addError(this->currentLoc,
+                        "Method '" + meta.name + "' does not belong to this object");
+                    break;
+                }
 
-                    Frame callee(*chunk.methodBodies[meta.bodyIndex]);
-                    callee.hasThis = true;
-                    callee.thisObj = receiver;
+                Frame callee(*chunk.methodBodies[meta.bodyIndex]);
+                callee.hasThis = true;
+                callee.thisObj = receiver;
 
-                    if (!this->pushFrame(std::move(callee)))
-                        break;
+                if (!this->pushFrame(std::move(callee)))
+                    break;
 
-                    Frame& top = this->frames.back();
-                    for (int i = 0; i < meta.argCount; ++i)
-                        this->localPool[top.localsBase + meta.argCount - 1 - i] = this->pop();
+                Frame& top = this->frames.back();
+                for (int i = 0; i < meta.argCount; ++i)
+                    this->localPool[top.localsBase + meta.argCount - 1 - i] = this->pop();
             } break;
             case OpCode::CALL_METHOD_VIRTUAL: {
-                    const auto& meta = cur.virtualCalls[instr.operand];
+                const auto& meta = cur.virtualCalls[instr.operand];
 
-                    auto receiver = this->pop();
-                    if (!std::holds_alternative<ObjectRef>(receiver)) {
-                        this->diagnostics.addError(this->currentLoc, "Method call target is not an object");
-                        break;
-                    }
+                auto receiver = this->pop();
+                if (!std::holds_alternative<ObjectRef>(receiver)) {
+                    this->diagnostics.addError(this->currentLoc, "Method call target is not an object");
+                    break;
+                }
 
-                    auto obj = std::get<ObjectRef>(receiver);
-                    if (obj->classIndex < 0 || obj->classIndex >= static_cast<int>(chunk.classes.size())) {
-                        this->diagnostics.addError(this->currentLoc, "Invalid object class index");
-                        break;
-                    }
+                auto obj = std::get<ObjectRef>(receiver);
+                if (obj->classIndex < 0 || obj->classIndex >= static_cast<int>(chunk.classes.size())) {
+                    this->diagnostics.addError(this->currentLoc, "Invalid object class index");
+                    break;
+                }
 
-                    if (!this->isDerived(chunk, obj->classIndex, meta.classIndex)) {
-                        this->diagnostics.addError(this->currentLoc, "Method call target is not an instance of the expected class");
-                        break;
-                    }
+                if (!this->isDerived(chunk, obj->classIndex, meta.classIndex)) {
+                    this->diagnostics.addError(this->currentLoc, "Method call target is not an instance of the expected class");
+                    break;
+                }
 
-                    const auto& actualClass = chunk.classes[obj->classIndex];
-                    if (meta.ordinal < 0 || meta.ordinal >= static_cast<int>(actualClass.methods.size())) {
-                        this->diagnostics.addError(this->currentLoc, "Invalid method ordinal");
-                        break;
-                    }
+                const auto& actualClass = chunk.classes[obj->classIndex];
+                if (meta.ordinal < 0 || meta.ordinal >= static_cast<int>(actualClass.methods.size())) {
+                    this->diagnostics.addError(this->currentLoc, "Invalid method ordinal");
+                    break;
+                }
 
-                    const auto& method = chunk.methods[actualClass.methods[meta.ordinal]];
-                    if (method.argCount != meta.argCount) {
-                        this->diagnostics.addError(this->currentLoc,
-                            "Method '" + method.name + "' expects " + std::to_string(method.argCount) +
-                            " argument(s), got " + std::to_string(meta.argCount));
-                        break;
-                    }
+                const auto& method = chunk.methods[actualClass.methods[meta.ordinal]];
+                if (method.argCount != meta.argCount) {
+                    this->diagnostics.addError(this->currentLoc,
+                        "Method '" + method.name + "' expects " + std::to_string(method.argCount) +
+                        " argument(s), got " + std::to_string(meta.argCount));
+                    break;
+                }
 
-                    Frame callee(*chunk.methodBodies[method.bodyIndex]);
-                    callee.hasThis = true;
-                    callee.thisObj = receiver;
+                Frame callee(*chunk.methodBodies[method.bodyIndex]);
+                callee.hasThis = true;
+                callee.thisObj = receiver;
 
-                    if (!this->pushFrame(std::move(callee)))
-                        break;
+                if (!this->pushFrame(std::move(callee)))
+                    break;
 
-                    Frame& top = this->frames.back();
-                    for (int i = 0; i < method.argCount; ++i)
-                        this->localPool[top.localsBase + method.argCount - 1 - i] = this->pop();
+                Frame& top = this->frames.back();
+                for (int i = 0; i < method.argCount; ++i)
+                    this->localPool[top.localsBase + method.argCount - 1 - i] = this->pop();
             } break;
             case OpCode::CALL_METHOD_BY_NAME: {
-                    const auto& meta = cur.byNameCalls[instr.operand];
+                const auto& meta = cur.byNameCalls[instr.operand];
 
-                    auto receiver = this->pop();
-                    if (!std::holds_alternative<ObjectRef>(receiver)) {
-                        this->diagnostics.addError(this->currentLoc, "Method call target is not an object");
+                auto receiver = this->pop();
+                if (!std::holds_alternative<ObjectRef>(receiver)) {
+                    this->diagnostics.addError(this->currentLoc, "Method call target is not an object");
+                    break;
+                }
+
+                auto obj = std::get<ObjectRef>(receiver);
+                if (obj->classIndex < 0 || obj->classIndex >= static_cast<int>(chunk.classes.size())) {
+                    this->diagnostics.addError(this->currentLoc, "Invalid object class index");
+                    break;
+                }
+
+                const auto& cls = chunk.classes[obj->classIndex];
+                int ordinal = -1;
+                for (size_t o = 0; o < cls.methods.size(); ++o) {
+                    const auto& m = chunk.methods[cls.methods[o]];
+                    if (m.name == meta.methodName && m.argCount == meta.argCount) {
+                        ordinal = static_cast<int>(o);
                         break;
                     }
+                }
 
-                    auto obj = std::get<ObjectRef>(receiver);
-                    if (obj->classIndex < 0 || obj->classIndex >= static_cast<int>(chunk.classes.size())) {
-                        this->diagnostics.addError(this->currentLoc, "Invalid object class index");
-                        break;
-                    }
+                if (ordinal < 0) {
+                    this->diagnostics.addError(this->currentLoc,
+                        "Method '" + meta.methodName + "' not found on object of type '" + cls.name + "'");
+                    break;
+                }
 
-                    const auto& cls = chunk.classes[obj->classIndex];
-                    int ordinal = -1;
-                    for (size_t o = 0; o < cls.methods.size(); ++o) {
-                        const auto& m = chunk.methods[cls.methods[o]];
-                        if (m.name == meta.methodName && m.argCount == meta.argCount) {
-                            ordinal = static_cast<int>(o);
-                            break;
-                        }
-                    }
+                const auto& method = chunk.methods[cls.methods[ordinal]];
 
-                    if (ordinal < 0) {
-                        this->diagnostics.addError(this->currentLoc,
-                            "Method '" + meta.methodName + "' not found on object of type '" + cls.name + "'");
-                        break;
-                    }
+                Frame callee(*chunk.methodBodies[method.bodyIndex]);
+                callee.hasThis = true;
+                callee.thisObj = receiver;
 
-                    const auto& method = chunk.methods[cls.methods[ordinal]];
+                if (!this->pushFrame(std::move(callee)))
+                    break;
 
-                    Frame callee(*chunk.methodBodies[method.bodyIndex]);
-                    callee.hasThis = true;
-                    callee.thisObj = receiver;
-
-                    if (!this->pushFrame(std::move(callee)))
-                        break;
-
-                    Frame& top = this->frames.back();
-                    for (int i = 0; i < method.argCount; ++i)
-                        this->localPool[top.localsBase + method.argCount - 1 - i] = this->pop();
+                Frame& top = this->frames.back();
+                for (int i = 0; i < method.argCount; ++i)
+                    this->localPool[top.localsBase + method.argCount - 1 - i] = this->pop();
             } break;
             case OpCode::CALL_SUPER_CTOR: {
-                    const auto& meta = cur.superCalls[instr.operand];
+                const auto& meta = cur.superCalls[instr.operand];
 
-                    auto receiver = this->pop();
-                    if (!std::holds_alternative<ObjectRef>(receiver)) {
-                        this->diagnostics.addError(this->currentLoc, "Super constructor call target is not an object");
-                        break;
+                auto receiver = this->pop();
+                if (!std::holds_alternative<ObjectRef>(receiver)) {
+                    this->diagnostics.addError(this->currentLoc, "Super constructor call target is not an object");
+                    break;
+                }
+
+                if (meta.constructorIndex < 0) {
+                    if (meta.argCount != 0) {
+                        this->diagnostics.addError(this->currentLoc, "Base class has no constructor");
+                    } else {
+                        this->push(std::string(""));
                     }
+                    break;
+                }
 
-                    if (meta.constructorIndex < 0) {
-                        if (meta.argCount != 0) {
-                            this->diagnostics.addError(this->currentLoc, "Base class has no constructor");
-                        } else {
-                            this->push(std::string(""));
-                        }
-                        break;
-                    }
+                const auto& ctor = chunk.methods[meta.constructorIndex];
+                if (ctor.argCount != meta.argCount) {
+                    this->diagnostics.addError(this->currentLoc,
+                        "Base constructor expects " + std::to_string(ctor.argCount) +
+                        " argument(s), got " + std::to_string(meta.argCount));
+                    break;
+                }
 
-                    const auto& ctor = chunk.methods[meta.constructorIndex];
-                    if (ctor.argCount != meta.argCount) {
-                        this->diagnostics.addError(this->currentLoc,
-                            "Base constructor expects " + std::to_string(ctor.argCount) +
-                            " argument(s), got " + std::to_string(meta.argCount));
-                        break;
-                    }
+                Frame callee(*chunk.methodBodies[ctor.bodyIndex]);
+                callee.hasThis = true;
+                callee.thisObj = receiver;
 
-                    Frame callee(*chunk.methodBodies[ctor.bodyIndex]);
-                    callee.hasThis = true;
-                    callee.thisObj = receiver;
+                if (!this->pushFrame(std::move(callee)))
+                    break;
 
-                    if (!this->pushFrame(std::move(callee)))
-                        break;
-
-                    Frame& top = this->frames.back();
-                    for (int i = 0; i < ctor.argCount; ++i)
-                        this->localPool[top.localsBase + ctor.argCount - 1 - i] = this->pop();
+                Frame& top = this->frames.back();
+                for (int i = 0; i < ctor.argCount; ++i)
+                    this->localPool[top.localsBase + ctor.argCount - 1 - i] = this->pop();
             } break;
             default: break;
         }
@@ -197,82 +197,82 @@ namespace LOICollection::frontend::ir {
         const auto& placeholders = s.placeholders;
         switch (instr.op) {
             case OpCode::CALL_NATIVE_METHOD: {
-                    if (const auto violation = this->mBudget->accountNativeCall();
-                        violation != sandbox::SandboxBudget::Violation::None) {
-                        this->failBudget(violation, "Native call budget exhausted");
-                        break;
-                    }
+                if (const auto violation = this->mBudget->accountNativeCall();
+                    violation != sandbox::SandboxBudget::Violation::None) {
+                    this->failBudget(violation, "Native call budget exhausted");
+                    break;
+                }
 
-                    const auto& meta = chunk.nativeCalls[instr.operand];
+                const auto& meta = chunk.nativeCalls[instr.operand];
 
-                    if (meta.isStatic) {
-                        std::vector<ValueNode::ValueType> args(meta.argCount);
-                        for (int i = 0; i < meta.argCount; ++i)
-                            args[meta.argCount - 1 - i] = this->pop();
-
-                        auto result = ClassCall::getInstance().callStaticMethodCached(
-                            meta.className, meta.name, args, placeholders,
-                            this->mNativeStaticMethodSlots[instr.operand], this->diagnostics, this->currentLoc
-                        );
-
-                        if (!result.has_value()) {
-                            this->diagnostics.addError(this->currentLoc,
-                                "Native static method call failed '" + meta.className + "::" + meta.name +
-                                "': " + result.error().message());
-                            break;
-                        }
-
-                        this->push(result.value());
-                        break;
-                    }
-
-                    auto receiver = this->pop();
-                    if (!std::holds_alternative<ObjectRef>(receiver)) {
-                        std::string valueClassName = valueClassNameOf(receiver);
-                        if (valueClassName.empty()) {
-                            this->diagnostics.addError(this->currentLoc, "Native method call target is not an object");
-                            break;
-                        }
-
-                        std::vector<ValueNode::ValueType> args(meta.argCount);
-                        for (int i = 0; i < meta.argCount; ++i)
-                            args[meta.argCount - 1 - i] = this->pop();
-
-                        auto result = ClassCall::getInstance().callValueMethodCached(
-                            valueClassName, meta.name, receiver, args,
-                            this->mNativeValueMethodSlots[instr.operand], this->diagnostics, this->currentLoc
-                        );
-
-                        if (!result.has_value()) {
-                            this->diagnostics.addError(this->currentLoc,
-                                "Native value method call failed '" + valueClassName + "::" + meta.name +
-                                "': " + result.error().message());
-                            break;
-                        }
-
-                        this->push(result.value());
-                        break;
-                    }
-
-                    auto obj = std::get<ObjectRef>(receiver);
-
+                if (meta.isStatic) {
                     std::vector<ValueNode::ValueType> args(meta.argCount);
                     for (int i = 0; i < meta.argCount; ++i)
                         args[meta.argCount - 1 - i] = this->pop();
 
-                    auto result = ClassCall::getInstance().callMethodCached(
-                        obj->className, meta.name, args, obj, placeholders,
-                        this->mNativeMethodSlots[instr.operand], this->diagnostics, this->currentLoc
+                    auto result = ClassCall::getInstance().callStaticMethodCached(
+                        meta.className, meta.name, args, placeholders,
+                        this->mNativeStaticMethodSlots[instr.operand], this->diagnostics, this->currentLoc
                     );
 
                     if (!result.has_value()) {
                         this->diagnostics.addError(this->currentLoc,
-                            "Native method call failed '" + meta.className + "::" + meta.name +
+                            "Native static method call failed '" + meta.className + "::" + meta.name +
                             "': " + result.error().message());
                         break;
                     }
 
                     this->push(result.value());
+                    break;
+                }
+
+                auto receiver = this->pop();
+                if (!std::holds_alternative<ObjectRef>(receiver)) {
+                    std::string valueClassName = valueClassNameOf(receiver);
+                    if (valueClassName.empty()) {
+                        this->diagnostics.addError(this->currentLoc, "Native method call target is not an object");
+                        break;
+                    }
+
+                    std::vector<ValueNode::ValueType> args(meta.argCount);
+                    for (int i = 0; i < meta.argCount; ++i)
+                        args[meta.argCount - 1 - i] = this->pop();
+
+                    auto result = ClassCall::getInstance().callValueMethodCached(
+                        valueClassName, meta.name, receiver, args,
+                        this->mNativeValueMethodSlots[instr.operand], this->diagnostics, this->currentLoc
+                    );
+
+                    if (!result.has_value()) {
+                        this->diagnostics.addError(this->currentLoc,
+                            "Native value method call failed '" + valueClassName + "::" + meta.name +
+                            "': " + result.error().message());
+                        break;
+                    }
+
+                    this->push(result.value());
+                    break;
+                }
+
+                auto obj = std::get<ObjectRef>(receiver);
+
+                std::vector<ValueNode::ValueType> args(meta.argCount);
+                for (int i = 0; i < meta.argCount; ++i)
+                    args[meta.argCount - 1 - i] = this->pop();
+
+                auto result = ClassCall::getInstance().callMethodCached(
+                    obj->className, meta.name, args, obj, placeholders,
+                    this->mNativeMethodSlots[instr.operand], this->diagnostics, this->currentLoc
+                );
+
+                if (!result.has_value()) {
+                    this->diagnostics.addError(this->currentLoc,
+                        "Native method call failed '" + meta.className + "::" + meta.name +
+                        "': " + result.error().message());
+                    break;
+                }
+
+                this->push(result.value());
             } break;
             default: break;
         }
@@ -283,66 +283,66 @@ namespace LOICollection::frontend::ir {
         const BytecodeChunk& chunk = s.chunk;
         switch (instr.op) {
             case OpCode::CALL_FUNC: {
-                    const auto& meta = chunk.methods[instr.operand];
+                const auto& meta = chunk.methods[instr.operand];
 
-                    Frame callee(*chunk.methodBodies[meta.bodyIndex]);
-                    callee.hasThis = false;
+                Frame callee(*chunk.methodBodies[meta.bodyIndex]);
+                callee.hasThis = false;
 
-                    if (!this->pushFrame(std::move(callee)))
-                        break;
+                if (!this->pushFrame(std::move(callee)))
+                    break;
 
-                    Frame& top = this->frames.back();
-                    for (int i = 0; i < meta.argCount; ++i)
-                        this->localPool[top.localsBase + meta.argCount - 1 - i] = this->pop();
+                Frame& top = this->frames.back();
+                for (int i = 0; i < meta.argCount; ++i)
+                    this->localPool[top.localsBase + meta.argCount - 1 - i] = this->pop();
             } break;
             case OpCode::CALL_LAMBDA: {
-                    auto funcValue = this->pop();
-                    if (!std::holds_alternative<FunctionRefPtr>(funcValue)) {
-                        this->diagnostics.addError(this->currentLoc, "Attempted to call a non-function value");
+                auto funcValue = this->pop();
+                if (!std::holds_alternative<FunctionRefPtr>(funcValue)) {
+                    this->diagnostics.addError(this->currentLoc, "Attempted to call a non-function value");
+                    break;
+                }
+
+                auto func = std::get<FunctionRefPtr>(funcValue);
+                if (instr.operand != func->argCount) {
+                    this->diagnostics.addError(this->currentLoc,
+                        "Function expects " + std::to_string(func->argCount) +
+                        " argument(s), got " + std::to_string(instr.operand));
+                    break;
+                }
+
+                if (!func->owner ||
+                    func->bodyIndex < 0 ||
+                    func->bodyIndex >= static_cast<int>(func->owner->methodBodies.size())) {
+                    this->diagnostics.addError(this->currentLoc, "Invalid function body index");
+                    break;
+                }
+
+                Frame callee(*func->owner->methodBodies[func->bodyIndex]);
+                callee.hasThis = func->hasThis;
+                if (func->hasThis) {
+                    auto self = func->thisObj.lock();
+                    if (!self) {
+                        this->diagnostics.addError(this->currentLoc, "Method receiver has been released");
                         break;
                     }
 
-                    auto func = std::get<FunctionRefPtr>(funcValue);
-                    if (instr.operand != func->argCount) {
-                        this->diagnostics.addError(this->currentLoc,
-                            "Function expects " + std::to_string(func->argCount) +
-                            " argument(s), got " + std::to_string(instr.operand));
-                        break;
-                    }
+                    callee.thisObj = self;
+                }
 
-                    if (!func->owner ||
-                        func->bodyIndex < 0 ||
-                        func->bodyIndex >= static_cast<int>(func->owner->methodBodies.size())) {
-                        this->diagnostics.addError(this->currentLoc, "Invalid function body index");
-                        break;
-                    }
+                const size_t paramBase = func->captures.size();
+                if (paramBase + static_cast<size_t>(func->argCount) > callee.localsSize) {
+                    this->diagnostics.addError(this->currentLoc, "Lambda frame is too small for its parameters");
+                    break;
+                }
 
-                    Frame callee(*func->owner->methodBodies[func->bodyIndex]);
-                    callee.hasThis = func->hasThis;
-                    if (func->hasThis) {
-                        auto self = func->thisObj.lock();
-                        if (!self) {
-                            this->diagnostics.addError(this->currentLoc, "Method receiver has been released");
-                            break;
-                        }
+                if (!this->pushFrame(std::move(callee)))
+                    break;
 
-                        callee.thisObj = self;
-                    }
+                Frame& top = this->frames.back();
+                std::copy_n(func->captures.begin(), paramBase, this->localPool.begin() + top.localsBase);
 
-                    const size_t paramBase = func->captures.size();
-                    if (paramBase + static_cast<size_t>(func->argCount) > callee.localsSize) {
-                        this->diagnostics.addError(this->currentLoc, "Lambda frame is too small for its parameters");
-                        break;
-                    }
-
-                    if (!this->pushFrame(std::move(callee)))
-                        break;
-
-                    Frame& top = this->frames.back();
-                    std::copy_n(func->captures.begin(), paramBase, this->localPool.begin() + top.localsBase);
-
-                    for (int i = 0; i < func->argCount; ++i)
-                        this->localPool[top.localsBase + paramBase + func->argCount - 1 - i] = this->pop();
+                for (int i = 0; i < func->argCount; ++i)
+                    this->localPool[top.localsBase + paramBase + func->argCount - 1 - i] = this->pop();
             } break;
             default: break;
         }
@@ -354,63 +354,63 @@ namespace LOICollection::frontend::ir {
         const auto& placeholders = s.placeholders;
         switch (instr.op) {
             case OpCode::CALL: {
-                    if (const auto violation = this->mBudget->accountNativeCall();
-                        violation != sandbox::SandboxBudget::Violation::None) {
-                        this->failBudget(violation, "Native call budget exhausted");
-                        break;
-                    }
+                if (const auto violation = this->mBudget->accountNativeCall();
+                    violation != sandbox::SandboxBudget::Violation::None) {
+                    this->failBudget(violation, "Native call budget exhausted");
+                    break;
+                }
 
-                    const auto& meta = cur.functions[instr.operand];
+                const auto& meta = cur.functions[instr.operand];
 
-                    CallbackTypeValues args;
-                    args.reserve(meta.argCount);
-                    for (int i = 0; i < meta.argCount; ++i)
-                        args.push_back(this->pop());
+                CallbackTypeValues args;
+                args.reserve(meta.argCount);
+                for (int i = 0; i < meta.argCount; ++i)
+                    args.push_back(this->pop());
 
-                    std::ranges::reverse(args);
+                std::ranges::reverse(args);
 
-                    auto ns = meta.name.substr(0, meta.name.find("::"));
-                    auto func = meta.name.substr(meta.name.find("::") + 2);
-                    auto result = FunctionCall::getInstance().callFunctionCached(
-                        ns, func, args, placeholders,
-                        this->mFunctionCallSlots[instr.operand], this->diagnostics, this->currentLoc
-                    );
+                auto ns = meta.name.substr(0, meta.name.find("::"));
+                auto func = meta.name.substr(meta.name.find("::") + 2);
+                auto result = FunctionCall::getInstance().callFunctionCached(
+                    ns, func, args, placeholders,
+                    this->mFunctionCallSlots[instr.operand], this->diagnostics, this->currentLoc
+                );
 
-                    if (!result.has_value()) {
-                        this->diagnostics.addError(this->currentLoc, result.error().message());
-                        this->push(ValueNode::ValueType{});
-                        break;
-                    }
+                if (!result.has_value()) {
+                    this->diagnostics.addError(this->currentLoc, result.error().message());
+                    this->push(ValueNode::ValueType{});
+                    break;
+                }
 
-                    this->push(result.value());
+                this->push(result.value());
             } break;
             case OpCode::CALL_MACRO: {
-                    if (const auto violation = this->mBudget->accountNativeCall();
-                        violation != sandbox::SandboxBudget::Violation::None) {
-                        this->failBudget(violation, "Native call budget exhausted");
-                        break;
-                    }
+                if (const auto violation = this->mBudget->accountNativeCall();
+                    violation != sandbox::SandboxBudget::Violation::None) {
+                    this->failBudget(violation, "Native call budget exhausted");
+                    break;
+                }
 
-                    const auto& meta = cur.macros[instr.operand];
+                const auto& meta = cur.macros[instr.operand];
 
-                    CallbackTypeValues args;
-                    args.reserve(meta.argCount);
-                    for (int i = 0; i < meta.argCount; ++i)
-                        args.push_back(this->pop());
+                CallbackTypeValues args;
+                args.reserve(meta.argCount);
+                for (int i = 0; i < meta.argCount; ++i)
+                    args.push_back(this->pop());
 
-                    std::ranges::reverse(args);
+                std::ranges::reverse(args);
                     
-                    auto result = MacroCall::getInstance().callMacro(
-                        meta.name, args, placeholders, this->diagnostics, this->currentLoc
-                    );
+                auto result = MacroCall::getInstance().callMacro(
+                    meta.name, args, placeholders, this->diagnostics, this->currentLoc
+                );
 
-                    if (!result.has_value()) {
-                        this->diagnostics.addError(this->currentLoc, result.error().message());
-                        this->push(ValueNode::ValueType{});
-                        break;
-                    }
+                if (!result.has_value()) {
+                    this->diagnostics.addError(this->currentLoc, result.error().message());
+                    this->push(ValueNode::ValueType{});
+                    break;
+                }
 
-                    this->push(result.value());
+                this->push(result.value());
             } break;
             default: break;
         }

--- a/src/LOICollectionA/frontend/ir/vm/VMExecCall.cpp
+++ b/src/LOICollectionA/frontend/ir/vm/VMExecCall.cpp
@@ -54,11 +54,12 @@ namespace LOICollection::frontend::ir {
                     callee.hasThis = true;
                     callee.thisObj = receiver;
 
-                    for (int i = 0; i < meta.argCount; ++i)
-                        callee.locals[meta.argCount - 1 - i] = this->pop();
-
                     if (!this->pushFrame(std::move(callee)))
                         break;
+
+                    Frame& top = this->frames.back();
+                    for (int i = 0; i < meta.argCount; ++i)
+                        this->localPool[top.localsBase + meta.argCount - 1 - i] = this->pop();
             } break;
             case OpCode::CALL_METHOD_VIRTUAL: {
                     const auto& meta = cur.virtualCalls[instr.operand];
@@ -98,11 +99,12 @@ namespace LOICollection::frontend::ir {
                     callee.hasThis = true;
                     callee.thisObj = receiver;
 
-                    for (int i = 0; i < method.argCount; ++i)
-                        callee.locals[method.argCount - 1 - i] = this->pop();
-
                     if (!this->pushFrame(std::move(callee)))
                         break;
+
+                    Frame& top = this->frames.back();
+                    for (int i = 0; i < method.argCount; ++i)
+                        this->localPool[top.localsBase + method.argCount - 1 - i] = this->pop();
             } break;
             case OpCode::CALL_METHOD_BY_NAME: {
                     const auto& meta = cur.byNameCalls[instr.operand];
@@ -141,11 +143,12 @@ namespace LOICollection::frontend::ir {
                     callee.hasThis = true;
                     callee.thisObj = receiver;
 
-                    for (int i = 0; i < method.argCount; ++i)
-                        callee.locals[method.argCount - 1 - i] = this->pop();
-
                     if (!this->pushFrame(std::move(callee)))
                         break;
+
+                    Frame& top = this->frames.back();
+                    for (int i = 0; i < method.argCount; ++i)
+                        this->localPool[top.localsBase + method.argCount - 1 - i] = this->pop();
             } break;
             case OpCode::CALL_SUPER_CTOR: {
                     const auto& meta = cur.superCalls[instr.operand];
@@ -177,11 +180,12 @@ namespace LOICollection::frontend::ir {
                     callee.hasThis = true;
                     callee.thisObj = receiver;
 
-                    for (int i = 0; i < ctor.argCount; ++i)
-                        callee.locals[ctor.argCount - 1 - i] = this->pop();
-
                     if (!this->pushFrame(std::move(callee)))
                         break;
+
+                    Frame& top = this->frames.back();
+                    for (int i = 0; i < ctor.argCount; ++i)
+                        this->localPool[top.localsBase + ctor.argCount - 1 - i] = this->pop();
             } break;
             default: break;
         }
@@ -281,18 +285,15 @@ namespace LOICollection::frontend::ir {
             case OpCode::CALL_FUNC: {
                     const auto& meta = chunk.methods[instr.operand];
 
-                    std::vector<ValueNode::ValueType> args(meta.argCount);
-                    for (int i = 0; i < meta.argCount; ++i)
-                        args[meta.argCount - 1 - i] = this->pop();
-
                     Frame callee(*chunk.methodBodies[meta.bodyIndex]);
                     callee.hasThis = false;
 
-                    for (int i = 0; i < meta.argCount; ++i)
-                        callee.locals[i] = args[i];
-
                     if (!this->pushFrame(std::move(callee)))
                         break;
+
+                    Frame& top = this->frames.back();
+                    for (int i = 0; i < meta.argCount; ++i)
+                        this->localPool[top.localsBase + meta.argCount - 1 - i] = this->pop();
             } break;
             case OpCode::CALL_LAMBDA: {
                     auto funcValue = this->pop();
@@ -329,18 +330,19 @@ namespace LOICollection::frontend::ir {
                     }
 
                     const size_t paramBase = func->captures.size();
-                    if (paramBase + static_cast<size_t>(func->argCount) > callee.locals.size()) {
+                    if (paramBase + static_cast<size_t>(func->argCount) > callee.localsSize) {
                         this->diagnostics.addError(this->currentLoc, "Lambda frame is too small for its parameters");
                         break;
                     }
 
-                    std::copy_n(func->captures.begin(), paramBase, callee.locals.begin());
-
-                    for (int i = 0; i < func->argCount; ++i)
-                        callee.locals[paramBase + func->argCount - 1 - i] = this->pop();
-
                     if (!this->pushFrame(std::move(callee)))
                         break;
+
+                    Frame& top = this->frames.back();
+                    std::copy_n(func->captures.begin(), paramBase, this->localPool.begin() + top.localsBase);
+
+                    for (int i = 0; i < func->argCount; ++i)
+                        this->localPool[top.localsBase + paramBase + func->argCount - 1 - i] = this->pop();
             } break;
             default: break;
         }

--- a/src/LOICollectionA/frontend/ir/vm/VMExecObject.cpp
+++ b/src/LOICollectionA/frontend/ir/vm/VMExecObject.cpp
@@ -282,9 +282,11 @@ namespace LOICollection::frontend::ir {
                     func->hasThis = frame.hasThis;
                     if (frame.hasThis)
                         func->thisObj = std::get<ObjectRef>(frame.thisObj);
+                    const size_t captureCount =
+                        std::min(static_cast<size_t>(meta.captureCount), frame.localsSize);
                     func->captures.assign(
-                        frame.locals.begin(),
-                        frame.locals.begin() + std::min(static_cast<size_t>(meta.captureCount), frame.locals.size())
+                        this->localPool.begin() + frame.localsBase,
+                        this->localPool.begin() + frame.localsBase + captureCount
                     );
                     func->globals = this->globals;
 
@@ -352,16 +354,6 @@ namespace LOICollection::frontend::ir {
 
                     const auto& cls = chunk.classes[instr.operand];
 
-                    std::vector<ValueNode::ValueType> args;
-
-                    if (cls.constructorIndex != -1) {
-                        const auto& ctor = chunk.methods[cls.constructorIndex];
-                        args.resize(ctor.argCount);
-
-                        for (int i = 0; i < ctor.argCount; ++i)
-                            args[ctor.argCount - 1 - i] = this->pop();
-                    }
-
                     auto obj = std::make_shared<Object>();
                     obj->className = cls.name;
                     obj->classIndex = instr.operand;
@@ -382,11 +374,12 @@ namespace LOICollection::frontend::ir {
                         callee.hasPending = true;
                         callee.pendingPush = obj;
 
-                        for (int i = 0; i < ctor.argCount; ++i)
-                            callee.locals[i] = args[i];
-
                         if (!this->pushFrame(std::move(callee)))
                             break;
+
+                        Frame& top = this->frames.back();
+                        for (int i = 0; i < ctor.argCount; ++i)
+                            this->localPool[top.localsBase + ctor.argCount - 1 - i] = this->pop();
                     } else {
                         this->push(obj);
                     }

--- a/src/LOICollectionA/frontend/ir/vm/VMExecObject.cpp
+++ b/src/LOICollectionA/frontend/ir/vm/VMExecObject.cpp
@@ -38,124 +38,124 @@ namespace LOICollection::frontend::ir {
         const BytecodeChunk& cur = s.cur;
         switch (instr.op) {
             case OpCode::LOAD_FIELD: {
-                    const auto& name = std::get<std::string>(cur.constants[instr.operand]);
-                    auto objValue = this->pop();
+                const auto& name = std::get<std::string>(cur.constants[instr.operand]);
+                auto objValue = this->pop();
 
-                    if (std::holds_alternative<ArrayRef>(objValue)) {
-                        this->diagnostics.addError(this->currentLoc, "Array has no field: " + name);
-                        break;
-                    }
+                if (std::holds_alternative<ArrayRef>(objValue)) {
+                    this->diagnostics.addError(this->currentLoc, "Array has no field: " + name);
+                    break;
+                }
 
-                    if (std::holds_alternative<std::string>(objValue)) {
-                        this->diagnostics.addError(this->currentLoc, "String has no field: " + name);
-                        break;
-                    }
+                if (std::holds_alternative<std::string>(objValue)) {
+                    this->diagnostics.addError(this->currentLoc, "String has no field: " + name);
+                    break;
+                }
 
-                    if (!std::holds_alternative<ObjectRef>(objValue)) {
-                        this->diagnostics.addError(this->currentLoc, "Cannot load field '" + name + "' from a non-object value");
-                        break;
-                    }
+                if (!std::holds_alternative<ObjectRef>(objValue)) {
+                    this->diagnostics.addError(this->currentLoc, "Cannot load field '" + name + "' from a non-object value");
+                    break;
+                }
 
-                    auto obj = std::get<ObjectRef>(objValue);
-                    const auto* field = obj->fieldAt(this->resolveFieldSlot(*obj, name, instr), name);
-                    if (!field) {
-                        this->diagnostics.addError(this->currentLoc, "Object has no field: " + name);
-                        break;
-                    }
+                auto obj = std::get<ObjectRef>(objValue);
+                const auto* field = obj->fieldAt(this->resolveFieldSlot(*obj, name, instr), name);
+                if (!field) {
+                    this->diagnostics.addError(this->currentLoc, "Object has no field: " + name);
+                    break;
+                }
 
-                    this->push(*field);
+                this->push(*field);
             } break;
             case OpCode::STORE_FIELD: {
-                    const auto& name = std::get<std::string>(cur.constants[instr.operand]);
-                    auto objValue = this->pop();
-                    auto val = this->pop();
+                const auto& name = std::get<std::string>(cur.constants[instr.operand]);
+                auto objValue = this->pop();
+                auto val = this->pop();
 
-                    if (!std::holds_alternative<ObjectRef>(objValue)) {
-                        this->diagnostics.addError(this->currentLoc, "Cannot store field '" + name + "' on a non-object value");
-                        break;
-                    }
+                if (!std::holds_alternative<ObjectRef>(objValue)) {
+                    this->diagnostics.addError(this->currentLoc, "Cannot store field '" + name + "' on a non-object value");
+                    break;
+                }
 
-                    auto obj = std::get<ObjectRef>(objValue);
-                    obj->fieldAtOrSpill(this->resolveFieldSlot(*obj, name, instr), name) = std::move(val);
+                auto obj = std::get<ObjectRef>(objValue);
+                obj->fieldAtOrSpill(this->resolveFieldSlot(*obj, name, instr), name) = std::move(val);
             } break;
             case OpCode::LOAD_FIELD_SLOT: {
-                    auto objValue = this->pop();
+                auto objValue = this->pop();
 
-                    if (!std::holds_alternative<ObjectRef>(objValue)) {
-                        this->diagnostics.addError(this->currentLoc, "Cannot load a field from a non-object value");
-                        break;
-                    }
+                if (!std::holds_alternative<ObjectRef>(objValue)) {
+                    this->diagnostics.addError(this->currentLoc, "Cannot load a field from a non-object value");
+                    break;
+                }
 
-                    auto obj = std::get<ObjectRef>(objValue);
-                    if (instr.operand >= 0 && static_cast<size_t>(instr.operand) >= obj->slots.size())
-                        obj->adoptLayout();
+                auto obj = std::get<ObjectRef>(objValue);
+                if (instr.operand >= 0 && static_cast<size_t>(instr.operand) >= obj->slots.size())
+                    obj->adoptLayout();
 
-                    if (instr.operand < 0 || static_cast<size_t>(instr.operand) >= obj->slots.size()) {
-                        this->diagnostics.addError(this->currentLoc, "Field slot index out of range");
-                        break;
-                    }
+                if (instr.operand < 0 || static_cast<size_t>(instr.operand) >= obj->slots.size()) {
+                    this->diagnostics.addError(this->currentLoc, "Field slot index out of range");
+                    break;
+                }
 
-                    this->push(obj->slots[static_cast<size_t>(instr.operand)]);
+                this->push(obj->slots[static_cast<size_t>(instr.operand)]);
             } break;
             case OpCode::STORE_FIELD_SLOT: {
-                    auto objValue = this->pop();
-                    auto val = this->pop();
+                auto objValue = this->pop();
+                auto val = this->pop();
 
-                    if (!std::holds_alternative<ObjectRef>(objValue)) {
-                        this->diagnostics.addError(this->currentLoc, "Cannot store a field on a non-object value");
-                        break;
-                    }
+                if (!std::holds_alternative<ObjectRef>(objValue)) {
+                    this->diagnostics.addError(this->currentLoc, "Cannot store a field on a non-object value");
+                    break;
+                }
 
-                    auto obj = std::get<ObjectRef>(objValue);
-                    if (instr.operand >= 0 && static_cast<size_t>(instr.operand) >= obj->slots.size())
-                        obj->adoptLayout();
+                auto obj = std::get<ObjectRef>(objValue);
+                if (instr.operand >= 0 && static_cast<size_t>(instr.operand) >= obj->slots.size())
+                    obj->adoptLayout();
 
-                    if (instr.operand < 0 || static_cast<size_t>(instr.operand) >= obj->slots.size()) {
-                        this->diagnostics.addError(this->currentLoc, "Field slot index out of range");
-                        break;
-                    }
+                if (instr.operand < 0 || static_cast<size_t>(instr.operand) >= obj->slots.size()) {
+                    this->diagnostics.addError(this->currentLoc, "Field slot index out of range");
+                    break;
+                }
 
-                    obj->slots[static_cast<size_t>(instr.operand)] = std::move(val);
+                obj->slots[static_cast<size_t>(instr.operand)] = std::move(val);
             } break;
             case OpCode::BIND_THIS: {
-                    if (instr.operand <= 0 || this->stack.empty())
-                        break;
+                if (instr.operand <= 0 || this->stack.empty())
+                    break;
 
-                    const size_t depth = static_cast<size_t>(instr.operand);
-                    if (depth >= this->stack.size())
-                        break;
+                const size_t depth = static_cast<size_t>(instr.operand);
+                if (depth >= this->stack.size())
+                    break;
 
-                    const auto* self = std::get_if<ObjectRef>(&this->stack.back());
-                    if (!self || !*self)
-                        break;
+                const auto* self = std::get_if<ObjectRef>(&this->stack.back());
+                if (!self || !*self)
+                    break;
 
-                    auto& slot = this->stack[this->stack.size() - 1 - depth];
-                    auto* func = std::get_if<FunctionRefPtr>(&slot);
-                    if (!func || !*func)
-                        break;
+                auto& slot = this->stack[this->stack.size() - 1 - depth];
+                auto* func = std::get_if<FunctionRefPtr>(&slot);
+                if (!func || !*func)
+                    break;
 
-                    (*func)->hasThis = true;
-                    (*func)->thisObj = *self;
+                (*func)->hasThis = true;
+                (*func)->thisObj = *self;
 
-                    for (auto& captured : (*func)->captures) {
-                        if (const auto* held = std::get_if<ObjectRef>(&captured); held && *held == *self)
-                            captured = std::monostate{};
-                    }
+                for (auto& captured : (*func)->captures) {
+                    if (const auto* held = std::get_if<ObjectRef>(&captured); held && *held == *self)
+                        captured = std::monostate{};
+                }
             } break;
             case OpCode::LOAD_LEN: {
-                    auto iterable = this->pop();
+                auto iterable = this->pop();
 
-                    if (std::holds_alternative<ArrayRef>(iterable)) {
-                        this->push(static_cast<int>(std::get<ArrayRef>(iterable)->elements.size()));
-                        break;
-                    }
+                if (std::holds_alternative<ArrayRef>(iterable)) {
+                    this->push(static_cast<int>(std::get<ArrayRef>(iterable)->elements.size()));
+                    break;
+                }
 
-                    if (std::holds_alternative<std::string>(iterable)) {
-                        this->push(static_cast<int>(codepointCount(std::get<std::string>(iterable))));
-                        break;
-                    }
+                if (std::holds_alternative<std::string>(iterable)) {
+                    this->push(static_cast<int>(codepointCount(std::get<std::string>(iterable))));
+                    break;
+                }
 
-                    this->diagnostics.addError(this->currentLoc, "Cannot take length of a non-iterable value");
+                this->diagnostics.addError(this->currentLoc, "Cannot take length of a non-iterable value");
             } break;
             default: break;
         }
@@ -165,102 +165,102 @@ namespace LOICollection::frontend::ir {
         const auto& instr = s.instr;
         switch (instr.op) {
             case OpCode::MAKE_ARRAY: {
-                    int count = instr.operand;
-                    if (count < 0 || count > static_cast<int>(this->stack.size())) {
-                        this->diagnostics.addError(this->currentLoc, "Invalid array literal size");
-                        break;
-                    }
+                int count = instr.operand;
+                if (count < 0 || count > static_cast<int>(this->stack.size())) {
+                    this->diagnostics.addError(this->currentLoc, "Invalid array literal size");
+                    break;
+                }
 
-                    if (const auto violation = this->mBudget->accountArray(static_cast<std::size_t>(count));
-                        violation != sandbox::SandboxBudget::Violation::None) {
-                        this->failBudget(violation, "Array size budget exhausted");
-                        break;
-                    }
+                if (const auto violation = this->mBudget->accountArray(static_cast<std::size_t>(count));
+                    violation != sandbox::SandboxBudget::Violation::None) {
+                    this->failBudget(violation, "Array size budget exhausted");
+                    break;
+                }
 
-                    auto arr = std::make_shared<ArrayValue>();
-                    arr->elements.resize(count);
-                    for (int i = count - 1; i >= 0; --i)
-                        arr->elements[i] = this->pop();
+                auto arr = std::make_shared<ArrayValue>();
+                arr->elements.resize(count);
+                for (int i = count - 1; i >= 0; --i)
+                    arr->elements[i] = this->pop();
 
-                    this->push(arr);
+                this->push(arr);
             } break;
             case OpCode::LOAD_INDEX: {
-                    auto indexValue = this->pop();
-                    auto targetValue = this->pop();
+                auto indexValue = this->pop();
+                auto targetValue = this->pop();
 
-                    if (!std::holds_alternative<int>(indexValue)) {
-                        this->diagnostics.addError(this->currentLoc, "Index must be an int");
+                if (!std::holds_alternative<int>(indexValue)) {
+                    this->diagnostics.addError(this->currentLoc, "Index must be an int");
+                    break;
+                }
+
+                int index = std::get<int>(indexValue);
+
+                if (const auto* text = std::get_if<std::string>(&targetValue)) {
+                    if (index < 0) {
+                        this->diagnostics.addError(this->currentLoc, "String index out of range");
                         break;
                     }
 
-                    int index = std::get<int>(indexValue);
-
-                    if (const auto* text = std::get_if<std::string>(&targetValue)) {
-                        if (index < 0) {
-                            this->diagnostics.addError(this->currentLoc, "String index out of range");
-                            break;
-                        }
-
-                        auto character = codepointAt(*text, static_cast<size_t>(index));
-                        if (!character) {
-                            this->diagnostics.addError(this->currentLoc, "String index out of range");
-                            break;
-                        }
-
-                        this->push(std::move(*character));
+                    auto character = codepointAt(*text, static_cast<size_t>(index));
+                    if (!character) {
+                        this->diagnostics.addError(this->currentLoc, "String index out of range");
                         break;
                     }
 
-                    if (!std::holds_alternative<ArrayRef>(targetValue)) {
-                        this->diagnostics.addError(this->currentLoc, "Cannot index a non-array value");
-                        break;
-                    }
+                    this->push(std::move(*character));
+                    break;
+                }
 
-                    auto arr = std::get<ArrayRef>(targetValue);
-                    if (index < 0 || index >= static_cast<int>(arr->elements.size())) {
-                        this->diagnostics.addError(this->currentLoc, "Array index out of range");
-                        break;
-                    }
+                if (!std::holds_alternative<ArrayRef>(targetValue)) {
+                    this->diagnostics.addError(this->currentLoc, "Cannot index a non-array value");
+                    break;
+                }
 
-                    this->push(arr->elements[index]);
+                auto arr = std::get<ArrayRef>(targetValue);
+                if (index < 0 || index >= static_cast<int>(arr->elements.size())) {
+                    this->diagnostics.addError(this->currentLoc, "Array index out of range");
+                    break;
+                }
+
+                this->push(arr->elements[index]);
             } break;
             case OpCode::STORE_INDEX: {
-                    auto indexValue = this->pop();
-                    auto targetValue = this->pop();
-                    auto value = this->pop();
+                auto indexValue = this->pop();
+                auto targetValue = this->pop();
+                auto value = this->pop();
 
-                    if (!std::holds_alternative<ArrayRef>(targetValue)) {
-                        this->diagnostics.addError(this->currentLoc, "Cannot index a non-array value");
+                if (!std::holds_alternative<ArrayRef>(targetValue)) {
+                    this->diagnostics.addError(this->currentLoc, "Cannot index a non-array value");
+                    break;
+                }
+                if (!std::holds_alternative<int>(indexValue)) {
+                    this->diagnostics.addError(this->currentLoc, "Array index must be an int");
+                    break;
+                }
+
+                auto arr = std::get<ArrayRef>(targetValue);
+                int index = std::get<int>(indexValue);
+                if (index < 0 || index > static_cast<int>(arr->elements.size())) {
+                    this->diagnostics.addError(this->currentLoc, "Array index out of range");
+                    break;
+                }
+
+                if (auto* nested = std::get_if<ArrayRef>(&value); nested && nested->get() == arr.get()) {
+                    this->diagnostics.addError(this->currentLoc,
+                        "Circular reference: an array cannot contain itself");
+                    break;
+                }
+
+                if (index == static_cast<int>(arr->elements.size())) {
+                    if (static_cast<std::size_t>(index + 1) > this->mBudget->maxArrayElements) {
+                        this->failBudget(sandbox::SandboxBudget::Violation::ArrayElementLimit, "Array size budget exhausted");
                         break;
                     }
-                    if (!std::holds_alternative<int>(indexValue)) {
-                        this->diagnostics.addError(this->currentLoc, "Array index must be an int");
-                        break;
-                    }
 
-                    auto arr = std::get<ArrayRef>(targetValue);
-                    int index = std::get<int>(indexValue);
-                    if (index < 0 || index > static_cast<int>(arr->elements.size())) {
-                        this->diagnostics.addError(this->currentLoc, "Array index out of range");
-                        break;
-                    }
-
-                    if (auto* nested = std::get_if<ArrayRef>(&value); nested && nested->get() == arr.get()) {
-                        this->diagnostics.addError(this->currentLoc,
-                            "Circular reference: an array cannot contain itself");
-                        break;
-                    }
-
-                    if (index == static_cast<int>(arr->elements.size())) {
-                        if (static_cast<std::size_t>(index + 1) > this->mBudget->maxArrayElements) {
-                            this->failBudget(sandbox::SandboxBudget::Violation::ArrayElementLimit, "Array size budget exhausted");
-                            break;
-                        }
-
-                        arr->elements.push_back(value);
-                    } else {
-                        arr->elements[index] = value;
-                    }
+                    arr->elements.push_back(value);
+                } else {
+                    arr->elements[index] = value;
+                }
             } break;
             default: break;
         }
@@ -273,32 +273,32 @@ namespace LOICollection::frontend::ir {
         const auto& owner = s.owner;
         switch (instr.op) {
             case OpCode::MAKE_LAMBDA: {
-                    const auto& meta = cur.lambdas[instr.operand];
+                const auto& meta = cur.lambdas[instr.operand];
 
-                    auto func = std::make_shared<FunctionRef>();
-                    func->owner = owner;
-                    func->bodyIndex = meta.bodyIndex;
-                    func->argCount = meta.argCount;
-                    func->hasThis = frame.hasThis;
-                    if (frame.hasThis)
-                        func->thisObj = std::get<ObjectRef>(frame.thisObj);
-                    const size_t captureCount =
-                        std::min(static_cast<size_t>(meta.captureCount), frame.localsSize);
-                    func->captures.assign(
-                        this->localPool.begin() + frame.localsBase,
-                        this->localPool.begin() + frame.localsBase + captureCount
-                    );
-                    func->globals = this->globals;
+                auto func = std::make_shared<FunctionRef>();
+                func->owner = owner;
+                func->bodyIndex = meta.bodyIndex;
+                func->argCount = meta.argCount;
+                func->hasThis = frame.hasThis;
+                if (frame.hasThis)
+                    func->thisObj = std::get<ObjectRef>(frame.thisObj);
+                const size_t captureCount =
+                    std::min(static_cast<size_t>(meta.captureCount), frame.localsSize);
+                func->captures.assign(
+                    this->localPool.begin() + frame.localsBase,
+                    this->localPool.begin() + frame.localsBase + captureCount
+                );
+                func->globals = this->globals;
 
-                    this->push(func);
+                this->push(func);
             } break;
             case OpCode::LOAD_THIS: {
-                    if (!frame.hasThis) {
-                        this->diagnostics.addError(this->currentLoc, "'this' is not available in the current context");
-                        break;
-                    }
+                if (!frame.hasThis) {
+                    this->diagnostics.addError(this->currentLoc, "'this' is not available in the current context");
+                    break;
+                }
 
-                    this->push(frame.thisObj);
+                this->push(frame.thisObj);
             } break;
             default: break;
         }
@@ -310,31 +310,31 @@ namespace LOICollection::frontend::ir {
         const BytecodeChunk& chunk = s.chunk;
         switch (instr.op) {
             case OpCode::INSTANCEOF: {
-                    const auto& name = std::get<std::string>(cur.constants[instr.operand]);
-                    auto value = this->pop();
+                const auto& name = std::get<std::string>(cur.constants[instr.operand]);
+                auto value = this->pop();
 
-                    if (!std::holds_alternative<ObjectRef>(value)) {
-                        this->push(false);
-                        break;
-                    }
+                if (!std::holds_alternative<ObjectRef>(value)) {
+                    this->push(false);
+                    break;
+                }
 
-                    auto obj = std::get<ObjectRef>(value);
-                    bool result = (obj->className == name);
+                auto obj = std::get<ObjectRef>(value);
+                bool result = (obj->className == name);
 
-                    if (!result && obj->classIndex >= 0) {
-                        int targetIdx = -1;
-                        for (size_t i = 0; i < chunk.classes.size(); ++i) {
-                            if (chunk.classes[i].name == name) {
-                                targetIdx = static_cast<int>(i);
-                                break;
-                            }
+                if (!result && obj->classIndex >= 0) {
+                    int targetIdx = -1;
+                    for (size_t i = 0; i < chunk.classes.size(); ++i) {
+                        if (chunk.classes[i].name == name) {
+                            targetIdx = static_cast<int>(i);
+                            break;
                         }
-
-                        if (targetIdx >= 0)
-                            result = this->isDerived(chunk, obj->classIndex, targetIdx);
                     }
 
-                    this->push(result);
+                    if (targetIdx >= 0)
+                        result = this->isDerived(chunk, obj->classIndex, targetIdx);
+                }
+
+                this->push(result);
             } break;
             default: break;
         }
@@ -346,69 +346,69 @@ namespace LOICollection::frontend::ir {
         const auto& placeholders = s.placeholders;
         switch (instr.op) {
             case OpCode::NEW: {
-                    if (const auto violation = this->mBudget->accountObject();
-                        violation != sandbox::SandboxBudget::Violation::None) {
-                        this->failBudget(violation, "Object count budget exhausted");
+                if (const auto violation = this->mBudget->accountObject();
+                    violation != sandbox::SandboxBudget::Violation::None) {
+                    this->failBudget(violation, "Object count budget exhausted");
+                    break;
+                }
+
+                const auto& cls = chunk.classes[instr.operand];
+
+                auto obj = std::make_shared<Object>();
+                obj->className = cls.name;
+                obj->classIndex = instr.operand;
+                obj->layout = this->classLayout(chunk, instr.operand);
+                obj->resize(cls.fieldNames.size());
+
+                for (size_t i = 0; i < cls.fieldNames.size(); ++i) {
+                    if (cls.hasDefault[i])
+                        obj->slots[i] = VM::cloneValue(cls.defaults[i]);
+                }
+
+                if (cls.constructorIndex != -1) {
+                    const auto& ctor = chunk.methods[cls.constructorIndex];
+
+                    Frame callee(*chunk.methodBodies[ctor.bodyIndex]);
+                    callee.hasThis = true;
+                    callee.thisObj = obj;
+                    callee.hasPending = true;
+                    callee.pendingPush = obj;
+
+                    if (!this->pushFrame(std::move(callee)))
                         break;
-                    }
 
-                    const auto& cls = chunk.classes[instr.operand];
-
-                    auto obj = std::make_shared<Object>();
-                    obj->className = cls.name;
-                    obj->classIndex = instr.operand;
-                    obj->layout = this->classLayout(chunk, instr.operand);
-                    obj->resize(cls.fieldNames.size());
-
-                    for (size_t i = 0; i < cls.fieldNames.size(); ++i) {
-                        if (cls.hasDefault[i])
-                            obj->slots[i] = VM::cloneValue(cls.defaults[i]);
-                    }
-
-                    if (cls.constructorIndex != -1) {
-                        const auto& ctor = chunk.methods[cls.constructorIndex];
-
-                        Frame callee(*chunk.methodBodies[ctor.bodyIndex]);
-                        callee.hasThis = true;
-                        callee.thisObj = obj;
-                        callee.hasPending = true;
-                        callee.pendingPush = obj;
-
-                        if (!this->pushFrame(std::move(callee)))
-                            break;
-
-                        Frame& top = this->frames.back();
-                        for (int i = 0; i < ctor.argCount; ++i)
-                            this->localPool[top.localsBase + ctor.argCount - 1 - i] = this->pop();
-                    } else {
-                        this->push(obj);
-                    }
+                    Frame& top = this->frames.back();
+                    for (int i = 0; i < ctor.argCount; ++i)
+                        this->localPool[top.localsBase + ctor.argCount - 1 - i] = this->pop();
+                } else {
+                    this->push(obj);
+                }
             } break;
             case OpCode::NEW_NATIVE: {
-                    if (const auto violation = this->mBudget->accountObject();
-                        violation != sandbox::SandboxBudget::Violation::None) {
-                        this->failBudget(violation, "Object count budget exhausted");
-                        break;
-                    }
+                if (const auto violation = this->mBudget->accountObject();
+                    violation != sandbox::SandboxBudget::Violation::None) {
+                    this->failBudget(violation, "Object count budget exhausted");
+                    break;
+                }
 
-                    const auto& meta = chunk.nativeCalls[instr.operand];
+                const auto& meta = chunk.nativeCalls[instr.operand];
 
-                    std::vector<ValueNode::ValueType> args(meta.argCount);
-                    for (int i = 0; i < meta.argCount; ++i)
-                        args[meta.argCount - 1 - i] = this->pop();
+                std::vector<ValueNode::ValueType> args(meta.argCount);
+                for (int i = 0; i < meta.argCount; ++i)
+                    args[meta.argCount - 1 - i] = this->pop();
 
-                    auto result = ClassCall::getInstance().createCached(
-                        meta.className, args, placeholders,
-                        this->mNativeConstructorSlots[instr.operand], this->diagnostics, this->currentLoc
-                    );
+                auto result = ClassCall::getInstance().createCached(
+                    meta.className, args, placeholders,
+                    this->mNativeConstructorSlots[instr.operand], this->diagnostics, this->currentLoc
+                );
 
-                    if (!result.has_value()) {
-                        this->diagnostics.addError(this->currentLoc,
-                            "Failed to create native class '" + meta.className + "': " + result.error().message());
-                        break;
-                    }
+                if (!result.has_value()) {
+                    this->diagnostics.addError(this->currentLoc,
+                        "Failed to create native class '" + meta.className + "': " + result.error().message());
+                    break;
+                }
 
-                    this->push(result.value());
+                this->push(result.value());
             } break;
             default: break;
         }

--- a/src/LOICollectionA/frontend/ir/vm/VMExecObject.cpp
+++ b/src/LOICollectionA/frontend/ir/vm/VMExecObject.cpp
@@ -18,6 +18,21 @@
 
 namespace LOICollection::frontend::ir {
 
+    int VM::resolveFieldSlot(Object& obj, const std::string& name, const Instruction& instr) {
+        if (!obj.layout)
+            obj.adoptLayout();
+
+        FieldCacheSlot& cached = this->mFieldSlots[&instr];
+
+        if (cached.name != name || cached.layout != obj.layout.get()) {
+            cached.name = name;
+            cached.layout = obj.layout.get();
+            cached.slot = obj.slotOf(name);
+        }
+
+        return cached.slot;
+    }
+
     void VM::execFieldAccess(ExecArgs& s) {
         const auto& instr = s.instr;
         const BytecodeChunk& cur = s.cur;
@@ -42,7 +57,7 @@ namespace LOICollection::frontend::ir {
                     }
 
                     auto obj = std::get<ObjectRef>(objValue);
-                    const auto* field = obj->find(name);
+                    const auto* field = obj->fieldAt(this->resolveFieldSlot(*obj, name, instr), name);
                     if (!field) {
                         this->diagnostics.addError(this->currentLoc, "Object has no field: " + name);
                         break;
@@ -60,7 +75,8 @@ namespace LOICollection::frontend::ir {
                         break;
                     }
 
-                    std::get<ObjectRef>(objValue)->assign(name, val);
+                    auto obj = std::get<ObjectRef>(objValue);
+                    obj->fieldAtOrSpill(this->resolveFieldSlot(*obj, name, instr), name) = std::move(val);
             } break;
             case OpCode::LOAD_FIELD_SLOT: {
                     auto objValue = this->pop();

--- a/src/LOICollectionA/frontend/ir/vm/VMExecStack.cpp
+++ b/src/LOICollectionA/frontend/ir/vm/VMExecStack.cpp
@@ -96,6 +96,8 @@ namespace LOICollection::frontend::ir {
             return false;
         }
 
+        frame.localsBase = this->localPool.size();
+        this->localPool.resize(this->localPool.size() + frame.localsSize);
         this->frames.push_back(std::move(frame));
         return true;
     }
@@ -220,20 +222,20 @@ namespace LOICollection::frontend::ir {
         Frame& frame = s.frame;
         switch (instr.op) {
             case OpCode::LOAD_SLOT: {
-                    if (instr.operand < 0 || static_cast<size_t>(instr.operand) >= frame.locals.size()) {
+                    if (instr.operand < 0 || static_cast<size_t>(instr.operand) >= frame.localsSize) {
                         this->diagnostics.addError(this->currentLoc, "Slot index out of range");
                         break;
                     }
 
-                    this->push(frame.locals[instr.operand]);
+                    this->push(this->localPool[frame.localsBase + instr.operand]);
             } break;
             case OpCode::STORE_SLOT: {
-                    if (instr.operand < 0 || static_cast<size_t>(instr.operand) >= frame.locals.size()) {
+                    if (instr.operand < 0 || static_cast<size_t>(instr.operand) >= frame.localsSize) {
                         this->diagnostics.addError(this->currentLoc, "Slot index out of range");
                         break;
                     }
 
-                    frame.locals[instr.operand] = this->pop();
+                    this->localPool[frame.localsBase + instr.operand] = this->pop();
             } break;
             case OpCode::DUP_STORE_SLOT: {
                     if (this->stack.empty()) {
@@ -241,12 +243,12 @@ namespace LOICollection::frontend::ir {
                         break;
                     }
 
-                    if (instr.operand < 0 || static_cast<size_t>(instr.operand) >= frame.locals.size()) {
+                    if (instr.operand < 0 || static_cast<size_t>(instr.operand) >= frame.localsSize) {
                         this->diagnostics.addError(this->currentLoc, "Slot index out of range");
                         break;
                     }
 
-                    frame.locals[instr.operand] = this->stack.back();
+                    this->localPool[frame.localsBase + instr.operand] = this->stack.back();
             } break;
             default: break;
         }

--- a/src/LOICollectionA/frontend/ir/vm/VMExecStack.cpp
+++ b/src/LOICollectionA/frontend/ir/vm/VMExecStack.cpp
@@ -34,13 +34,17 @@ namespace LOICollection::frontend::ir {
         this->stack.push_back(v);
     }
 
+    void VM::push(ValueNode::ValueType&& v) {
+        this->stack.push_back(std::move(v));
+    }
+
     ValueNode::ValueType VM::pop() {
         if (this->stack.empty()) {
             this->diagnostics.addError(this->currentLoc, "Stack underflow");
             return ValueNode::ValueType{};
         }
 
-        auto v = this->stack.back();
+        ValueNode::ValueType v = std::move(this->stack.back());
         this->stack.pop_back();
 
         return v;

--- a/src/LOICollectionA/frontend/ir/vm/VMExecStack.cpp
+++ b/src/LOICollectionA/frontend/ir/vm/VMExecStack.cpp
@@ -107,26 +107,26 @@ namespace LOICollection::frontend::ir {
         const BytecodeChunk& cur = s.cur;
         switch (instr.op) {
             case OpCode::PUSH_INT: {
-                    this->push(VM::cloneValue(cur.constants[instr.operand]));
+                this->push(VM::cloneValue(cur.constants[instr.operand]));
             } break;
             case OpCode::PUSH_FLOAT: {
-                    this->push(VM::cloneValue(cur.constants[instr.operand]));
+                this->push(VM::cloneValue(cur.constants[instr.operand]));
             } break;
             case OpCode::PUSH_BOOL: {
-                    this->push(VM::cloneValue(cur.constants[instr.operand]));
+                this->push(VM::cloneValue(cur.constants[instr.operand]));
             } break;
             case OpCode::PUSH_NONE: {
-                    this->push(VM::cloneValue(cur.constants[instr.operand]));
+                this->push(VM::cloneValue(cur.constants[instr.operand]));
             } break;
             case OpCode::PUSH_STR: {
-                    const auto& value = std::get<std::string>(cur.constants[instr.operand]);
-                    if (const auto violation = this->mBudget->accountString(value.size());
-                        violation != sandbox::SandboxBudget::Violation::None) {
-                        this->failBudget(violation, "String size budget exhausted");
-                        break;
-                    }
+                const auto& value = std::get<std::string>(cur.constants[instr.operand]);
+                if (const auto violation = this->mBudget->accountString(value.size());
+                    violation != sandbox::SandboxBudget::Violation::None) {
+                    this->failBudget(violation, "String size budget exhausted");
+                    break;
+                }
 
-                    this->push(value);
+                this->push(value);
             } break;
             default: break;
         }
@@ -136,44 +136,44 @@ namespace LOICollection::frontend::ir {
         const auto& instr = s.instr;
         switch (instr.op) {
             case OpCode::POP: {
-                    this->pop();
+                this->pop();
             } break;
             case OpCode::DUP: {
-                    if (this->stack.empty()) {
-                        this->diagnostics.addError(this->currentLoc, "Stack underflow during DUP");
-                        break;
-                    }
+                if (this->stack.empty()) {
+                    this->diagnostics.addError(this->currentLoc, "Stack underflow during DUP");
+                    break;
+                }
 
-                    this->stack.push_back(this->stack.back());
+                this->stack.push_back(this->stack.back());
             } break;
             case OpCode::DUP2: {
-                    if (this->stack.size() < 2) {
-                        this->diagnostics.addError(this->currentLoc, "Stack underflow during DUP2");
-                        break;
-                    }
+                if (this->stack.size() < 2) {
+                    this->diagnostics.addError(this->currentLoc, "Stack underflow during DUP2");
+                    break;
+                }
 
-                    auto second = this->stack[this->stack.size() - 2];
-                    this->stack.push_back(second);
-                    this->stack.push_back(this->stack[this->stack.size() - 2]);
+                auto second = this->stack[this->stack.size() - 2];
+                this->stack.push_back(second);
+                this->stack.push_back(this->stack[this->stack.size() - 2]);
             } break;
             case OpCode::ROT3: {
-                    if (this->stack.size() < 3) {
-                        this->diagnostics.addError(this->currentLoc, "Stack underflow during ROT3");
-                        break;
-                    }
+                if (this->stack.size() < 3) {
+                    this->diagnostics.addError(this->currentLoc, "Stack underflow during ROT3");
+                    break;
+                }
 
-                    auto bottom = std::move(this->stack[this->stack.size() - 3]);
-                    this->stack.erase(this->stack.end() - 3);
-                    this->stack.push_back(std::move(bottom));
+                auto bottom = std::move(this->stack[this->stack.size() - 3]);
+                this->stack.erase(this->stack.end() - 3);
+                this->stack.push_back(std::move(bottom));
             } break;
             case OpCode::SWAP2: {
-                    if (this->stack.size() < 4) {
-                        this->diagnostics.addError(this->currentLoc, "Stack underflow during SWAP2");
-                        break;
-                    }
+                if (this->stack.size() < 4) {
+                    this->diagnostics.addError(this->currentLoc, "Stack underflow during SWAP2");
+                    break;
+                }
 
-                    std::swap(this->stack[this->stack.size() - 4], this->stack[this->stack.size() - 2]);
-                    std::swap(this->stack[this->stack.size() - 3], this->stack[this->stack.size() - 1]);
+                std::swap(this->stack[this->stack.size() - 4], this->stack[this->stack.size() - 2]);
+                std::swap(this->stack[this->stack.size() - 3], this->stack[this->stack.size() - 1]);
             } break;
             default: break;
         }
@@ -183,35 +183,35 @@ namespace LOICollection::frontend::ir {
         const auto& instr = s.instr;
         switch (instr.op) {
             case OpCode::IS_NONE: {
-                    auto value = this->pop();
-                    this->push(std::holds_alternative<std::monostate>(value));
+                auto value = this->pop();
+                this->push(std::holds_alternative<std::monostate>(value));
             } break;
             case OpCode::UNWRAP: {
-                    auto value = this->pop();
-                    if (std::holds_alternative<std::monostate>(value)) {
-                        this->diagnostics.addError(this->currentLoc, "Optional value is empty");
-                        break;
-                    }
+                auto value = this->pop();
+                if (std::holds_alternative<std::monostate>(value)) {
+                    this->diagnostics.addError(this->currentLoc, "Optional value is empty");
+                    break;
+                }
 
-                    this->push(value);
+                this->push(value);
             } break;
             case OpCode::TYPE_OF: {
-                    auto value = this->pop();
-                    this->push(VM::typeNameOf(value));
+                auto value = this->pop();
+                this->push(VM::typeNameOf(value));
             } break;
             case OpCode::HAS_VALUE: {
-                    auto value = this->pop();
-                    this->push(!std::holds_alternative<std::monostate>(value));
+                auto value = this->pop();
+                this->push(!std::holds_alternative<std::monostate>(value));
             } break;
             case OpCode::DUP_IS_NONE: {
-                    if (this->stack.empty()) {
-                        this->diagnostics.addError(this->currentLoc, "Stack underflow during DUP_IS_NONE");
-                        break;
-                    }
+                if (this->stack.empty()) {
+                    this->diagnostics.addError(this->currentLoc, "Stack underflow during DUP_IS_NONE");
+                    break;
+                }
 
-                    this->push(ValueNode::ValueType{
-                        std::holds_alternative<std::monostate>(this->stack.back())
-                    });
+                this->push(ValueNode::ValueType{
+                    std::holds_alternative<std::monostate>(this->stack.back())
+                });
             } break;
             default: break;
         }
@@ -222,33 +222,33 @@ namespace LOICollection::frontend::ir {
         Frame& frame = s.frame;
         switch (instr.op) {
             case OpCode::LOAD_SLOT: {
-                    if (instr.operand < 0 || static_cast<size_t>(instr.operand) >= frame.localsSize) {
-                        this->diagnostics.addError(this->currentLoc, "Slot index out of range");
-                        break;
-                    }
+                if (instr.operand < 0 || static_cast<size_t>(instr.operand) >= frame.localsSize) {
+                    this->diagnostics.addError(this->currentLoc, "Slot index out of range");
+                    break;
+                }
 
-                    this->push(this->localPool[frame.localsBase + instr.operand]);
+                this->push(this->localPool[frame.localsBase + instr.operand]);
             } break;
             case OpCode::STORE_SLOT: {
-                    if (instr.operand < 0 || static_cast<size_t>(instr.operand) >= frame.localsSize) {
-                        this->diagnostics.addError(this->currentLoc, "Slot index out of range");
-                        break;
-                    }
+                if (instr.operand < 0 || static_cast<size_t>(instr.operand) >= frame.localsSize) {
+                    this->diagnostics.addError(this->currentLoc, "Slot index out of range");
+                    break;
+                }
 
-                    this->localPool[frame.localsBase + instr.operand] = this->pop();
+                this->localPool[frame.localsBase + instr.operand] = this->pop();
             } break;
             case OpCode::DUP_STORE_SLOT: {
-                    if (this->stack.empty()) {
-                        this->diagnostics.addError(this->currentLoc, "Stack underflow during DUP_STORE_SLOT");
-                        break;
-                    }
+                if (this->stack.empty()) {
+                    this->diagnostics.addError(this->currentLoc, "Stack underflow during DUP_STORE_SLOT");
+                    break;
+                }
 
-                    if (instr.operand < 0 || static_cast<size_t>(instr.operand) >= frame.localsSize) {
-                        this->diagnostics.addError(this->currentLoc, "Slot index out of range");
-                        break;
-                    }
+                if (instr.operand < 0 || static_cast<size_t>(instr.operand) >= frame.localsSize) {
+                    this->diagnostics.addError(this->currentLoc, "Slot index out of range");
+                    break;
+                }
 
-                    this->localPool[frame.localsBase + instr.operand] = this->stack.back();
+                this->localPool[frame.localsBase + instr.operand] = this->stack.back();
             } break;
             default: break;
         }
@@ -261,75 +261,75 @@ namespace LOICollection::frontend::ir {
         const BytecodeChunk& chunk = s.chunk;
         switch (instr.op) {
             case OpCode::LOAD_VAR: {
-                    const auto& name = std::get<std::string>(cur.constants[instr.operand]);
+                const auto& name = std::get<std::string>(cur.constants[instr.operand]);
 
-                    if (frame.hasThis) {
-                        auto obj = std::get<ObjectRef>(frame.thisObj);
+                if (frame.hasThis) {
+                    auto obj = std::get<ObjectRef>(frame.thisObj);
 
-                        if (obj->classIndex >= 0) {
-                            const auto& cls = chunk.classes[obj->classIndex];
-                            bool isField = std::ranges::find(cls.fieldNames, name) != cls.fieldNames.end();
+                    if (obj->classIndex >= 0) {
+                        const auto& cls = chunk.classes[obj->classIndex];
+                        bool isField = std::ranges::find(cls.fieldNames, name) != cls.fieldNames.end();
 
-                            if (isField) {
-                                const auto* field = obj->find(name);
-                                if (!field) {
-                                    this->diagnostics.addError(this->currentLoc, "Object has no field: " + name);
-                                    break;
-                                }
-
-                                this->push(*field);
+                        if (isField) {
+                            const auto* field = obj->find(name);
+                            if (!field) {
+                                this->diagnostics.addError(this->currentLoc, "Object has no field: " + name);
                                 break;
                             }
-                        }
 
-                        if (const auto* existing = obj->find(name)) {
-                            this->push(*existing);
+                            this->push(*field);
                             break;
                         }
                     }
 
-                    std::string className;
-                    std::string fieldName;
-                    if (splitStaticMemberName(name, className, fieldName) &&
-                        std::ranges::none_of(chunk.classes, [&className](const auto& cls) {
-                            return cls.name == className;
-                        }) &&
-                        ClassCall::getInstance().isRegistered(className) &&
-                        ClassCall::getInstance().hasStaticField(className, fieldName)) {
-                        auto result = ClassCall::getInstance().getStaticField(className, fieldName);
-                        if (!result.has_value()) {
-                            this->diagnostics.addError(this->currentLoc,
-                                "Failed to load native static field '" + name + "': " + result.error().message());
-                            break;
-                        }
+                    if (const auto* existing = obj->find(name)) {
+                        this->push(*existing);
+                        break;
+                    }
+                }
 
-                        this->push(result.value());
+                std::string className;
+                std::string fieldName;
+                if (splitStaticMemberName(name, className, fieldName) &&
+                    std::ranges::none_of(chunk.classes, [&className](const auto& cls) {
+                        return cls.name == className;
+                    }) &&
+                    ClassCall::getInstance().isRegistered(className) &&
+                    ClassCall::getInstance().hasStaticField(className, fieldName)) {
+                    auto result = ClassCall::getInstance().getStaticField(className, fieldName);
+                    if (!result.has_value()) {
+                        this->diagnostics.addError(this->currentLoc,
+                            "Failed to load native static field '" + name + "': " + result.error().message());
                         break;
                     }
 
-                    auto globalIt = this->globals->find(name);
-                    if (globalIt == this->globals->end()) {
-                        this->diagnostics.addError(this->currentLoc, "Undefined variable: " + name);
-                        break;
-                    }
+                    this->push(result.value());
+                    break;
+                }
 
-                    this->push(globalIt->second);
+                auto globalIt = this->globals->find(name);
+                if (globalIt == this->globals->end()) {
+                    this->diagnostics.addError(this->currentLoc, "Undefined variable: " + name);
+                    break;
+                }
+
+                this->push(globalIt->second);
             } break;
             case OpCode::STORE_VAR: {
-                    const auto& name = std::get<std::string>(cur.constants[instr.operand]);
+                const auto& name = std::get<std::string>(cur.constants[instr.operand]);
 
-                    auto val = this->pop();
+                auto val = this->pop();
 
-                    this->storeVariable(chunk, frame, name, val);
+                this->storeVariable(chunk, frame, name, val);
             } break;
             case OpCode::DUP_STORE: {
-                    if (this->stack.empty()) {
-                        this->diagnostics.addError(this->currentLoc, "Stack underflow during DUP_STORE");
-                        break;
-                    }
+                if (this->stack.empty()) {
+                    this->diagnostics.addError(this->currentLoc, "Stack underflow during DUP_STORE");
+                    break;
+                }
 
-                    const auto& name = std::get<std::string>(cur.constants[instr.operand]);
-                    this->storeVariable(chunk, frame, name, this->stack.back());
+                const auto& name = std::get<std::string>(cur.constants[instr.operand]);
+                this->storeVariable(chunk, frame, name, this->stack.back());
             } break;
             default: break;
         }

--- a/src/LOICollectionA/frontend/semantic/CallChecker.cpp
+++ b/src/LOICollectionA/frontend/semantic/CallChecker.cpp
@@ -174,10 +174,10 @@ namespace LOICollection::frontend {
         }
 
         if (targetType.kind == TypeKind::Unknown) {
-            ClassCall& classes = ClassCall::getInstance();
-            for (const auto& className : classes.getClassNames()) {
+            ClassCall& classCall = ClassCall::getInstance();
+            for (const auto& className : classCall.getClassNames()) {
                 std::vector<CallbackTypeArgs> signatures =
-                    classes.getValueMethodSignatures(className, node.methodName);
+                    classCall.getValueMethodSignatures(className, node.methodName);
 
                 for (const auto& signature : signatures) {
                     if (matchesNativeSignature(signature, argTypes)) {

--- a/tests/common/frontend/ASTTest.cpp
+++ b/tests/common/frontend/ASTTest.cpp
@@ -18,7 +18,7 @@ TEST(ASTTest, NodeTypesFromParsing) {
         ASSERT_EQ(ast->getType(), ASTNode::Type::Program);
 
         auto& program = static_cast<ProgramNode&>(*ast);
-        ASSERT_EQ(program.parts.size(), 1);
+        ASSERT_EQ(program.parts.size(), 1u);
         EXPECT_EQ(program.parts[0]->getType(), ASTNode::Type::Value);
     }
     {

--- a/tests/common/frontend/ASTTest.cpp
+++ b/tests/common/frontend/ASTTest.cpp
@@ -41,16 +41,16 @@ TEST(ASTTest, NodeTypesFromParsing) {
     }
 }
 
-namespace {
-    ASTNode::Type firstPartType(const std::string& source) {
-        DiagnosticEngine diagnostics;
-        Lexer lexer(source, diagnostics);
-        Parser parser(lexer, diagnostics);
+    namespace {
+        ASTNode::Type firstPartType(const std::string& source) {
+            DiagnosticEngine diagnostics;
+            Lexer lexer(source, diagnostics);
+            Parser parser(lexer, diagnostics);
 
-        auto ast = parser.parse();
-        auto& program = static_cast<ProgramNode&>(*ast);
-        return program.parts[0]->getType();
-    }
+            auto ast = parser.parse();
+            auto& program = static_cast<ProgramNode&>(*ast);
+            return program.parts[0]->getType();
+        }
 }
 
 TEST(ASTTest, ExpressionNodeTypes) {

--- a/tests/common/frontend/CallbackTest.cpp
+++ b/tests/common/frontend/CallbackTest.cpp
@@ -110,7 +110,7 @@ TEST(CallbackTest, ValuesToTypes) {
     CallbackTypeValues vals = { 1, 2.5f, std::string("hello"), true };
     
     auto types = valuesToTypes(vals, diagnostics);
-    ASSERT_EQ(types.size(), 4);
+    ASSERT_EQ(types.size(), 4u);
     EXPECT_EQ(types[0], ParamType::INT);
     EXPECT_EQ(types[1], ParamType::FLOAT);
     EXPECT_EQ(types[2], ParamType::STRING);
@@ -433,7 +433,7 @@ TEST(ClassCallCacheTest, MethodCacheFollowsReceiverClass) {
     auto& cc = ClassCall::getInstance();
     DiagnosticEngine diagnostics;
 
-    for (const std::string& name : { "CacheLeft", "CacheRight" }) {
+    for (const char* name : { "CacheLeft", "CacheRight" }) {
         cc.registerClass(name, {});
         cc.registerMethod(name, "who",
             [name](const ObjectRef&, const CallbackTypeValues&) -> TypedValue {

--- a/tests/common/frontend/CompoundAssignTest.cpp
+++ b/tests/common/frontend/CompoundAssignTest.cpp
@@ -40,8 +40,7 @@ TEST(CompoundAssignTest, IndexTargetPreservesOtherElements) {
 }
 
 TEST(CompoundAssignTest, IndexTargetEvaluatedExactlyOnce) {
-    // The index expression of "arr[n()] += 1" must be evaluated exactly once;
-    // a second evaluation would double the side effect inside n().
+    
     EXPECT_EQ(eval(
         "let calls = 0; "
         "let arr = [10, 20]; "

--- a/tests/common/frontend/ForInTest.cpp
+++ b/tests/common/frontend/ForInTest.cpp
@@ -265,8 +265,7 @@ TEST(ForInTest, NonIterable) {
 }
 
 TEST(ForInTest, LambdaCapturesCurrentIterationValue) {
-    // A lambda created inside the loop must capture the value of its own
-    // iteration, not a reference that later follows the loop variable.
+    
     EXPECT_EQ(eval(
         "let fns = []; "
         "for (item in [10, 20, 30]) [ "

--- a/tests/common/frontend/OptimizerTest.cpp
+++ b/tests/common/frontend/OptimizerTest.cpp
@@ -896,3 +896,18 @@ TEST(OptimizerTest, PassMaskTurnsOffDeadStoreElimination) {
     EXPECT_FALSE(noDeadStore.diagnostics.hasErrors());
     EXPECT_EQ(runChunk(noDeadStore.chunk, noDeadStore.diagnostics), runChunk(full.chunk, full.diagnostics));
 }
+
+TEST(OptimizerTest, RejectedFoldKeepsItsOperandsOnTheStack) {
+    auto program = compileAndOptimize("10.0 % 3.0");
+
+    EXPECT_FALSE(program.diagnostics.hasErrors());
+    EXPECT_EQ(countOp(*program.chunk, OpCode::MOD), 1);
+    EXPECT_GE(countOp(*program.chunk, OpCode::PUSH_FLOAT), 2);
+
+    VM vm(program.diagnostics);
+    [[maybe_unused]] auto result = vm.run(program.chunk, {});
+
+    EXPECT_TRUE(program.diagnostics.hasErrors());
+    EXPECT_EQ(program.diagnostics.getErrorMessage().find("Stack underflow"), std::string::npos);
+    EXPECT_NE(program.diagnostics.getErrorMessage().find("Modulo requires integral types"), std::string::npos);
+}

--- a/tests/common/frontend/OptimizerTest.cpp
+++ b/tests/common/frontend/OptimizerTest.cpp
@@ -14,59 +14,59 @@
 using namespace LOICollection::frontend;
 using namespace LOICollection::frontend::ir;
 
-namespace {
-    struct CompiledProgram {
-        std::shared_ptr<BytecodeChunk> chunk;
-        DiagnosticEngine diagnostics;
-        Optimizer::Stats stats;
-    };
+    namespace {
+        struct CompiledProgram {
+            std::shared_ptr<BytecodeChunk> chunk;
+            DiagnosticEngine diagnostics;
+            Optimizer::Stats stats;
+        };
 
-    CompiledProgram compileAndOptimize(const std::string& source, unsigned mask = Optimizer::allPasses) {
-        CompiledProgram out;
+        CompiledProgram compileAndOptimize(const std::string& source, unsigned mask = Optimizer::allPasses) {
+            CompiledProgram out;
 
-        Lexer lexer(source, out.diagnostics);
-        Parser parser(lexer, out.diagnostics);
+            Lexer lexer(source, out.diagnostics);
+            Parser parser(lexer, out.diagnostics);
 
-        auto ast = parser.parse();
-        if (ast->getType() == ASTNode::Type::Program) {
-            SemanticAnalyzer analyzer(out.diagnostics);
-            analyzer.analyze(static_cast<ProgramNode&>(*ast));
+            auto ast = parser.parse();
+            if (ast->getType() == ASTNode::Type::Program) {
+                SemanticAnalyzer analyzer(out.diagnostics);
+                analyzer.analyze(static_cast<ProgramNode&>(*ast));
+            }
+
+            Compiler compiler(out.diagnostics);
+            out.chunk = std::make_shared<BytecodeChunk>(compiler.compile(*ast));
+
+            Optimizer optimizer;
+            optimizer.setEnabledPasses(mask);
+            out.stats = optimizer.optimize(*out.chunk);
+
+            return out;
         }
 
-        Compiler compiler(out.diagnostics);
-        out.chunk = std::make_shared<BytecodeChunk>(compiler.compile(*ast));
-
-        Optimizer optimizer;
-        optimizer.setEnabledPasses(mask);
-        out.stats = optimizer.optimize(*out.chunk);
-
-        return out;
-    }
-
-    OpCode canonicalOp(OpCode op) {
-        switch (op) {
-            case OpCode::ADD_I: return OpCode::ADD;
-            case OpCode::SUB_I: return OpCode::SUB;
-            case OpCode::MUL_I: return OpCode::MUL;
-            case OpCode::MOD_I: return OpCode::MOD;
-            case OpCode::CMP_EQ_I: return OpCode::CMP_EQ;
-            case OpCode::CMP_NE_I: return OpCode::CMP_NE;
-            case OpCode::CMP_GT_I: return OpCode::CMP_GT;
-            case OpCode::CMP_LT_I: return OpCode::CMP_LT;
-            case OpCode::CMP_GE_I: return OpCode::CMP_GE;
-            case OpCode::CMP_LE_I: return OpCode::CMP_LE;
-            case OpCode::NEG_I: return OpCode::NEG;
-            default: return op;
+        OpCode canonicalOp(OpCode op) {
+            switch (op) {
+                case OpCode::ADD_I: return OpCode::ADD;
+                case OpCode::SUB_I: return OpCode::SUB;
+                case OpCode::MUL_I: return OpCode::MUL;
+                case OpCode::MOD_I: return OpCode::MOD;
+                case OpCode::CMP_EQ_I: return OpCode::CMP_EQ;
+                case OpCode::CMP_NE_I: return OpCode::CMP_NE;
+                case OpCode::CMP_GT_I: return OpCode::CMP_GT;
+                case OpCode::CMP_LT_I: return OpCode::CMP_LT;
+                case OpCode::CMP_GE_I: return OpCode::CMP_GE;
+                case OpCode::CMP_LE_I: return OpCode::CMP_LE;
+                case OpCode::NEG_I: return OpCode::NEG;
+                default: return op;
+            }
         }
-    }
 
-    bool containsOp(const BytecodeChunk& chunk, OpCode op) {
-        for (const auto& instr : chunk.code)
-            if (canonicalOp(instr.op) == op)
-                return true;
+        bool containsOp(const BytecodeChunk& chunk, OpCode op) {
+            for (const auto& instr : chunk.code)
+                if (canonicalOp(instr.op) == op)
+                    return true;
 
-        return false;
-    }
+            return false;
+        }
 }
 
 TEST(OptimizerTest, ConstantFolding) {
@@ -440,28 +440,28 @@ TEST(OptimizerTest, PropagationInvalidatedByCalls) {
     EXPECT_EQ(chunk.code.size(), 5u);
 }
 
-namespace {
-    std::size_t optimizeInvalidationProbe(OpCode op) {
-        ir::BytecodeChunk chunk;
-        chunk.constants.push_back(3);
-        chunk.constants.push_back(std::string("x"));
-        chunk.constants.push_back(std::string("hook"));
+    namespace {
+        std::size_t optimizeInvalidationProbe(OpCode op) {
+            ir::BytecodeChunk chunk;
+            chunk.constants.push_back(3);
+            chunk.constants.push_back(std::string("x"));
+            chunk.constants.push_back(std::string("hook"));
 
-        chunk.code = {
-            { OpCode::PUSH_INT, 0 },
-            { OpCode::STORE_VAR, 1 },
-            { op, 2 },
-            { OpCode::LOAD_VAR, 1 },
-            { OpCode::HALT, 0 }
-        };
+            chunk.code = {
+                { OpCode::PUSH_INT, 0 },
+                { OpCode::STORE_VAR, 1 },
+                { op, 2 },
+                { OpCode::LOAD_VAR, 1 },
+                { OpCode::HALT, 0 }
+            };
 
-        Optimizer optimizer;
-        optimizer.optimize(chunk);
+            Optimizer optimizer;
+            optimizer.optimize(chunk);
 
-        EXPECT_TRUE(containsOp(chunk, OpCode::LOAD_VAR));
+            EXPECT_TRUE(containsOp(chunk, OpCode::LOAD_VAR));
 
-        return chunk.code.size();
-    }
+            return chunk.code.size();
+        }
 }
 
 TEST(OptimizerTest, PropagationInvalidatedByByNameMethodCalls) {
@@ -714,11 +714,11 @@ TEST(OptimizerTest, CoalesceKeepsDuplicatedOperand) {
     EXPECT_FALSE(valueCase.diagnostics.hasErrors());
 }
 
-namespace {
-    std::string runChunk(const std::shared_ptr<BytecodeChunk>& chunk, DiagnosticEngine& diag) {
-        VM vm(diag);
-        return VM::valueToString(vm.run(chunk, {}));
-    }
+    namespace {
+        std::string runChunk(const std::shared_ptr<BytecodeChunk>& chunk, DiagnosticEngine& diag) {
+            VM vm(diag);
+            return VM::valueToString(vm.run(chunk, {}));
+        }
 }
 
 TEST(OptimizerTest, PassMaskTurnsOffConstantFolding) {
@@ -764,15 +764,15 @@ TEST(OptimizerTest, PassMaskDefaultsToEveryPassEnabled) {
     EXPECT_EQ(optimizer.enabledPasses(), Optimizer::allPasses);
 }
 
-namespace {
-    int countOp(const BytecodeChunk& chunk, OpCode op) {
-        int total = 0;
-        for (const auto& instr : chunk.code)
-            if (canonicalOp(instr.op) == op)
-                ++total;
+    namespace {
+        int countOp(const BytecodeChunk& chunk, OpCode op) {
+            int total = 0;
+            for (const auto& instr : chunk.code)
+                if (canonicalOp(instr.op) == op)
+                    ++total;
 
-        return total;
-    }
+            return total;
+        }
 }
 
 TEST(OptimizerTest, RemovesStoreOverwrittenBeforeAnyRead) {
@@ -890,22 +890,22 @@ TEST(OptimizerTest, RejectedFoldKeepsItsOperandsOnTheStack) {
     EXPECT_NE(program.diagnostics.getErrorMessage().find("Modulo requires integral types"), std::string::npos);
 }
 
-namespace {
-    int countOpEverywhere(const BytecodeChunk& chunk, OpCode op) {
-        int total = countOp(chunk, op);
-        for (const auto& body : chunk.methodBodies)
-            total += countOp(*body, op);
-        return total;
-    }
+    namespace {
+        int countOpEverywhere(const BytecodeChunk& chunk, OpCode op) {
+            int total = countOp(chunk, op);
+            for (const auto& body : chunk.methodBodies)
+                total += countOp(*body, op);
+            return total;
+        }
 
-    bool containsOpEverywhere(const BytecodeChunk& chunk, OpCode op) {
-        if (containsOp(chunk, op))
-            return true;
-        for (const auto& body : chunk.methodBodies)
-            if (containsOp(*body, op))
+        bool containsOpEverywhere(const BytecodeChunk& chunk, OpCode op) {
+            if (containsOp(chunk, op))
                 return true;
-        return false;
-    }
+            for (const auto& body : chunk.methodBodies)
+                if (containsOp(*body, op))
+                    return true;
+            return false;
+        }
 }
 
 TEST(OptimizerTest, EliminatesRepeatedSubexpression) {

--- a/tests/common/frontend/OptimizerTest.cpp
+++ b/tests/common/frontend/OptimizerTest.cpp
@@ -431,6 +431,38 @@ TEST(OptimizerTest, PropagationInvalidatedByCalls) {
     EXPECT_EQ(chunk.code.size(), 5u);
 }
 
+namespace {
+    std::size_t optimizeInvalidationProbe(OpCode op) {
+        ir::BytecodeChunk chunk;
+        chunk.constants.push_back(3);
+        chunk.constants.push_back(std::string("x"));
+        chunk.constants.push_back(std::string("hook"));
+
+        chunk.code = {
+            { OpCode::PUSH_INT, 0 },
+            { OpCode::STORE_VAR, 1 },
+            { op, 2 },
+            { OpCode::LOAD_VAR, 1 },
+            { OpCode::HALT, 0 }
+        };
+
+        Optimizer optimizer;
+        optimizer.optimize(chunk);
+
+        EXPECT_TRUE(containsOp(chunk, OpCode::LOAD_VAR));
+
+        return chunk.code.size();
+    }
+}
+
+TEST(OptimizerTest, PropagationInvalidatedByByNameMethodCalls) {
+    EXPECT_EQ(optimizeInvalidationProbe(OpCode::CALL_METHOD_BY_NAME), 5u);
+}
+
+TEST(OptimizerTest, PropagationInvalidatedByNativeMethodCalls) {
+    EXPECT_EQ(optimizeInvalidationProbe(OpCode::CALL_NATIVE_METHOD), 5u);
+}
+
 // ---- NOT / branch fusion -------------------------------------------------------
 
 TEST(OptimizerTest, FusesNotIntoBranchOpcode) {

--- a/tests/common/frontend/OptimizerTest.cpp
+++ b/tests/common/frontend/OptimizerTest.cpp
@@ -911,3 +911,60 @@ TEST(OptimizerTest, RejectedFoldKeepsItsOperandsOnTheStack) {
     EXPECT_EQ(program.diagnostics.getErrorMessage().find("Stack underflow"), std::string::npos);
     EXPECT_NE(program.diagnostics.getErrorMessage().find("Modulo requires integral types"), std::string::npos);
 }
+
+// ---- common subexpression elimination ----------------------------------------
+
+namespace {
+    int countOpEverywhere(const BytecodeChunk& chunk, OpCode op) {
+        int total = countOp(chunk, op);
+        for (const auto& body : chunk.methodBodies)
+            total += countOp(*body, op);
+        return total;
+    }
+
+    bool containsOpEverywhere(const BytecodeChunk& chunk, OpCode op) {
+        if (containsOp(chunk, op))
+            return true;
+        for (const auto& body : chunk.methodBodies)
+            if (containsOp(*body, op))
+                return true;
+        return false;
+    }
+}
+
+TEST(OptimizerTest, EliminatesRepeatedSubexpression) {
+    const std::string source =
+        "func f(a: int, b: int) -> int { return (a + b) * (a + b) + (a + b); }\n"
+        "f(2, 3)";
+
+    auto withCse = compileAndOptimize(source);
+    auto withoutCse = compileAndOptimize(
+        source, Optimizer::allPasses & ~static_cast<unsigned>(Optimizer::Pass::CSE));
+
+    EXPECT_FALSE(withCse.diagnostics.hasErrors());
+    EXPECT_FALSE(withoutCse.diagnostics.hasErrors());
+
+    EXPECT_LT(countOpEverywhere(*withCse.chunk, OpCode::ADD),
+        countOpEverywhere(*withoutCse.chunk, OpCode::ADD));
+    EXPECT_TRUE(containsOpEverywhere(*withCse.chunk, OpCode::DUP_STORE_SLOT));
+
+    VM vm(withCse.diagnostics);
+    EXPECT_EQ(VM::valueToString(vm.run(withCse.chunk, {})), "30");
+}
+
+TEST(OptimizerTest, CSEStaysCorrectAcrossCalls) {
+    const std::string source =
+        "func g(x: int) -> int { return x + 1; }\n"
+        "func f(a: int, b: int) -> int {\n"
+        "  let s = (a + b) + g(a);\n"
+        "  return (a + b) + g(a);\n"
+        "}\n"
+        "f(2, 3)";
+
+    auto program = compileAndOptimize(source);
+
+    EXPECT_FALSE(program.diagnostics.hasErrors());
+
+    VM vm(program.diagnostics);
+    EXPECT_EQ(VM::valueToString(vm.run(program.chunk, {})), "8");
+}

--- a/tests/common/frontend/OptimizerTest.cpp
+++ b/tests/common/frontend/OptimizerTest.cpp
@@ -783,3 +783,116 @@ TEST(OptimizerTest, PassMaskDefaultsToEveryPassEnabled) {
     optimizer.setEnabledPasses(Optimizer::allPasses);
     EXPECT_EQ(optimizer.enabledPasses(), Optimizer::allPasses);
 }
+
+// ---- dead store elimination ---------------------------------------------------
+
+namespace {
+    int countOp(const BytecodeChunk& chunk, OpCode op) {
+        int total = 0;
+        for (const auto& instr : chunk.code)
+            if (instr.op == op)
+                ++total;
+
+        return total;
+    }
+}
+
+TEST(OptimizerTest, RemovesStoreOverwrittenBeforeAnyRead) {
+    auto program = compileAndOptimize("let x = 1; x = 2; x");
+
+    EXPECT_FALSE(program.diagnostics.hasErrors());
+    EXPECT_EQ(countOp(*program.chunk, OpCode::STORE_VAR) + countOp(*program.chunk, OpCode::DUP_STORE), 1);
+    EXPECT_EQ(countOp(*program.chunk, OpCode::POP), 1);
+
+    VM vm(program.diagnostics);
+    EXPECT_EQ(VM::valueToString(vm.run(program.chunk, {})), "2");
+    EXPECT_FALSE(program.diagnostics.hasErrors());
+}
+
+TEST(OptimizerTest, RemovesDeadSlotStoreInStraightLineCode) {
+    ir::BytecodeChunk chunk;
+    chunk.slotCount = 1;
+    chunk.constants.push_back(1);
+    chunk.constants.push_back(2);
+
+    chunk.code = {
+        { OpCode::PUSH_INT, 0 },
+        { OpCode::STORE_SLOT, 0 },
+        { OpCode::PUSH_INT, 1 },
+        { OpCode::STORE_SLOT, 0 },
+        { OpCode::LOAD_SLOT, 0 },
+        { OpCode::HALT, 0 }
+    };
+
+    Optimizer optimizer;
+    optimizer.optimize(chunk);
+
+    EXPECT_EQ(countOp(chunk, OpCode::STORE_SLOT), 1);
+    EXPECT_EQ(countOp(chunk, OpCode::POP), 0);
+
+    DiagnosticEngine diag;
+    VM vm(diag);
+    EXPECT_EQ(VM::valueToString(vm.run(std::make_shared<BytecodeChunk>(std::move(chunk)), {})), "2");
+    EXPECT_FALSE(diag.hasErrors());
+}
+
+TEST(OptimizerTest, KeepsSlotStoreThatAReadObserves) {
+    ir::BytecodeChunk chunk;
+    chunk.slotCount = 2;
+
+    chunk.code = {
+        { OpCode::LOAD_SLOT, 1 },
+        { OpCode::STORE_SLOT, 0 },
+        { OpCode::LOAD_SLOT, 0 },
+        { OpCode::POP, 0 },
+        { OpCode::LOAD_SLOT, 1 },
+        { OpCode::STORE_SLOT, 0 },
+        { OpCode::LOAD_SLOT, 0 },
+        { OpCode::HALT, 0 }
+    };
+
+    Optimizer optimizer;
+    optimizer.optimize(chunk);
+
+    EXPECT_EQ(countOp(chunk, OpCode::STORE_SLOT), 2);
+}
+
+TEST(OptimizerTest, KeepsStoreThatPrecedesACall) {
+    ir::BytecodeChunk chunk;
+    chunk.slotCount = 1;
+    chunk.constants.push_back(1);
+    chunk.constants.push_back(2);
+    chunk.constants.push_back(std::string("hook"));
+
+    chunk.code = {
+        { OpCode::PUSH_INT, 0 },
+        { OpCode::STORE_SLOT, 0 },
+        { OpCode::CALL, 2 },
+        { OpCode::PUSH_INT, 1 },
+        { OpCode::STORE_SLOT, 0 },
+        { OpCode::LOAD_SLOT, 0 },
+        { OpCode::HALT, 0 }
+    };
+
+    Optimizer optimizer;
+    optimizer.optimize(chunk);
+
+    EXPECT_EQ(countOp(chunk, OpCode::STORE_SLOT), 2);
+}
+
+TEST(OptimizerTest, PassMaskTurnsOffDeadStoreElimination) {
+    const std::string source = "let x = 1; x = 2; x";
+
+    auto full = compileAndOptimize(source);
+    auto noDeadStore = compileAndOptimize(
+        source,
+        static_cast<unsigned>(Optimizer::Pass::ConstantFold) | static_cast<unsigned>(Optimizer::Pass::DeadCode));
+
+    EXPECT_LT(
+        countOp(*full.chunk, OpCode::STORE_VAR) + countOp(*full.chunk, OpCode::DUP_STORE),
+        countOp(*noDeadStore.chunk, OpCode::STORE_VAR) + countOp(*noDeadStore.chunk, OpCode::DUP_STORE));
+
+    EXPECT_FALSE(full.diagnostics.hasErrors());
+    EXPECT_FALSE(noDeadStore.diagnostics.hasErrors());
+    EXPECT_EQ(runChunk(noDeadStore.chunk, noDeadStore.diagnostics), runChunk(full.chunk, full.diagnostics));
+}

--- a/tests/common/frontend/OptimizerTest.cpp
+++ b/tests/common/frontend/OptimizerTest.cpp
@@ -968,3 +968,31 @@ TEST(OptimizerTest, CSEStaysCorrectAcrossCalls) {
     VM vm(program.diagnostics);
     EXPECT_EQ(VM::valueToString(vm.run(program.chunk, {})), "8");
 }
+
+// Rewriting inside a loop body shifts the distance between a jump and its target,
+// so the relative offsets of the back edge and the exit branch have to survive the
+// rewrite as well.
+TEST(OptimizerTest, CSEInsideLoopKeepsJumpOffsets) {
+    const std::string source =
+        "func f(a: int, b: int, n: int) -> int {\n"
+        "  let s = 0;\n"
+        "  let i = 0;\n"
+        "  while (i < n) [\n"
+        "    s = s + (a + b) * (a + b) + (a + b);\n"
+        "    i = i + 1;\n"
+        "  ]\n"
+        "  return s;\n"
+        "}\n"
+        "f(2, 3, 5)";
+
+    auto program = compileAndOptimize(source);
+
+    EXPECT_FALSE(program.diagnostics.hasErrors());
+    EXPECT_TRUE(containsOpEverywhere(*program.chunk, OpCode::DUP_STORE_SLOT));
+
+    VM vm(program.diagnostics);
+    auto result = vm.run(program.chunk, {});
+
+    EXPECT_FALSE(program.diagnostics.hasErrors());
+    EXPECT_EQ(VM::valueToString(result), "150");
+}

--- a/tests/common/frontend/OptimizerTest.cpp
+++ b/tests/common/frontend/OptimizerTest.cpp
@@ -328,8 +328,6 @@ TEST(OptimizerTest, LoopWithContinueSurvivesOptimization) {
     EXPECT_FALSE(program.diagnostics.hasErrors());
 }
 
-// ---- local constant propagation ------------------------------------------------
-
 TEST(OptimizerTest, PropagatesStoredScalarIntoArithmetic) {
     auto program = compileAndOptimize("let x = 4; x += 0; x");
 
@@ -368,8 +366,6 @@ TEST(OptimizerTest, PropagationTracksLatestAssignment) {
 }
 
 TEST(OptimizerTest, PropagationDropsSlotForNonScalarValues) {
-    // Forwarding an array reference would alias the pool constant on every load,
-    // so storing a non-scalar must retire the slot and keep the LOAD_VAR.
     auto program = compileAndOptimize("let x = [1, 2]; x = [3, 4]; x");
 
     EXPECT_FALSE(program.diagnostics.hasErrors());
@@ -391,8 +387,6 @@ TEST(OptimizerTest, PropagationInvalidatedAtBranchMerge) {
     EXPECT_EQ(VM::valueToString(vmTaken.run(taken.chunk, {})), "10");
     EXPECT_FALSE(taken.diagnostics.hasErrors());
 
-    // If the then-branch's r = 10 leaked past the merge point, the untaken
-    // branch would wrongly observe 10.
     auto untaken = compileAndOptimize(source + "f(2)");
     EXPECT_FALSE(untaken.diagnostics.hasErrors());
 
@@ -409,8 +403,6 @@ TEST(OptimizerTest, PropagationInvalidatedAtBranchMerge) {
 }
 
 TEST(OptimizerTest, PropagationInvalidatedByCalls) {
-    // Calls can execute script code that rebinds the variable, so the load
-    // after CALL must not be forwarded even though x was just stored.
     ir::BytecodeChunk chunk;
     chunk.constants.push_back(3);
     chunk.constants.push_back(std::string("x"));
@@ -463,11 +455,7 @@ TEST(OptimizerTest, PropagationInvalidatedByNativeMethodCalls) {
     EXPECT_EQ(optimizeInvalidationProbe(OpCode::CALL_NATIVE_METHOD), 5u);
 }
 
-// ---- NOT / branch fusion -------------------------------------------------------
-
 TEST(OptimizerTest, FusesNotIntoBranchOpcode) {
-    // The loop head is a merge point, so `i >= 2` stays dynamic: the leading
-    // NOT must fuse into the branch instead of evaluating at runtime.
     auto program = compileAndOptimize("let i = 0; while (!(i >= 2)) [ i = i + 1; ]; i");
 
     EXPECT_FALSE(program.diagnostics.hasErrors());
@@ -482,12 +470,7 @@ TEST(OptimizerTest, FusesNotIntoBranchOpcode) {
     EXPECT_FALSE(program.diagnostics.hasErrors());
 }
 
-// ---- fixed-point iteration -----------------------------------------------------
-
 TEST(OptimizerTest, FixedPointExposesPropagationAfterBranchRemoval) {
-    // Pass one folds x == 1 and deletes the else branch; only once the jump
-    // over it is gone does the final LOAD_VAR stop being a merge target and
-    // become forwardable in the next pass.
     auto program = compileAndOptimize("let x = 1; if (x == 1) [ let y = 10 : y = 20 ]; y");
 
     EXPECT_FALSE(program.diagnostics.hasErrors());
@@ -517,11 +500,7 @@ TEST(OptimizerTest, FixedPointExposesPropagationAfterBranchRemoval) {
     EXPECT_FALSE(program.diagnostics.hasErrors());
 }
 
-// ---- algebraic identity elimination --------------------------------------------
-
 TEST(OptimizerTest, EliminatesAlgebraicIdentities) {
-    // The kept operand is duplicated, so it is known but not removable: the
-    // identities 42 + 0 and 42 * 1 must drop their operand instead of folding.
     ir::BytecodeChunk chunk;
     chunk.constants.push_back(42);
     chunk.constants.push_back(0);
@@ -591,8 +570,6 @@ TEST(OptimizerTest, EliminatesFloatMulDivPowIdentities) {
 }
 
 TEST(OptimizerTest, FloatAddZeroIsNotIdentityFolded) {
-    // IEEE754: -0.0 + 0.0 == +0.0, so dropping a float `+ 0.0` would flip the
-    // sign of negative zero. The ADD has to run.
     ir::BytecodeChunk chunk;
     chunk.constants.push_back(-0.0f);
     chunk.constants.push_back(0.0f);
@@ -618,11 +595,7 @@ TEST(OptimizerTest, FloatAddZeroIsNotIdentityFolded) {
     EXPECT_FALSE(diag.hasErrors());
 }
 
-// ---- signed-zero semantics -----------------------------------------------------
-
 TEST(OptimizerTest, PropagatesSignedZeroCorrectly) {
-    // Pool dedup must not conflate -0.0 with +0.0 even though they compare
-    // equal: the forwarded load has to reproduce the stored negative zero.
     auto program = compileAndOptimize("let x = -0.0; x");
 
     EXPECT_FALSE(program.diagnostics.hasErrors());
@@ -636,7 +609,6 @@ TEST(OptimizerTest, PropagatesSignedZeroCorrectly) {
 }
 
 TEST(OptimizerTest, FoldsFloatAddZeroWithCorrectSignedZero) {
-    // Full folding computes the IEEE754 result: -0.0 + 0.0 is +0.0.
     auto program = compileAndOptimize("let x = -0.0; let y = x + 0.0; y");
 
     EXPECT_FALSE(program.diagnostics.hasErrors());
@@ -647,8 +619,6 @@ TEST(OptimizerTest, FoldsFloatAddZeroWithCorrectSignedZero) {
     EXPECT_EQ(VM::valueToString(vm.run(program.chunk, {})), "0");
     EXPECT_FALSE(program.diagnostics.hasErrors());
 }
-
-// ---- IS_NONE folding and constant-pool dedup -----------------------------------
 
 TEST(OptimizerTest, FoldsIsNoneOpcode) {
     ir::BytecodeChunk chunk;
@@ -699,7 +669,6 @@ TEST(OptimizerTest, ReusesScalarConstantsWhenFolding) {
     ASSERT_EQ(chunk.code.size(), 2u);
     EXPECT_EQ(chunk.code[0].op, OpCode::PUSH_INT);
     EXPECT_EQ(chunk.code[1].op, OpCode::HALT);
-    // the folded 5 reuses the existing pool slot instead of appending one
     EXPECT_EQ(chunk.code[0].operand, 0);
     EXPECT_EQ(chunk.constants.size(), 2u);
     EXPECT_EQ(std::get<int>(chunk.constants[chunk.code[0].operand]), 5);
@@ -710,11 +679,7 @@ TEST(OptimizerTest, ReusesScalarConstantsWhenFolding) {
     EXPECT_FALSE(diag.hasErrors());
 }
 
-// ---- coalesce keeps duplicated operands ----------------------------------------
-
 TEST(OptimizerTest, CoalesceKeepsDuplicatedOperand) {
-    // ?? duplicates the left operand before IS_NONE; the duplicate protects
-    // the original push from being dropped while only the copy is consumed.
     auto noneCase = compileAndOptimize("let x = None; x ?? \"d\"");
 
     EXPECT_FALSE(noneCase.diagnostics.hasErrors());
@@ -731,8 +696,6 @@ TEST(OptimizerTest, CoalesceKeepsDuplicatedOperand) {
     EXPECT_EQ(VM::valueToString(vmValue.run(valueCase.chunk, {})), "v");
     EXPECT_FALSE(valueCase.diagnostics.hasErrors());
 }
-
-// ---- pass mask (A/B comparison inside a single build) --------------------------
 
 namespace {
     std::string runChunk(const std::shared_ptr<BytecodeChunk>& chunk, DiagnosticEngine& diag) {

--- a/tests/common/frontend/OptimizerTest.cpp
+++ b/tests/common/frontend/OptimizerTest.cpp
@@ -43,9 +43,26 @@ namespace {
         return out;
     }
 
+    OpCode canonicalOp(OpCode op) {
+        switch (op) {
+            case OpCode::ADD_I: return OpCode::ADD;
+            case OpCode::SUB_I: return OpCode::SUB;
+            case OpCode::MUL_I: return OpCode::MUL;
+            case OpCode::MOD_I: return OpCode::MOD;
+            case OpCode::CMP_EQ_I: return OpCode::CMP_EQ;
+            case OpCode::CMP_NE_I: return OpCode::CMP_NE;
+            case OpCode::CMP_GT_I: return OpCode::CMP_GT;
+            case OpCode::CMP_LT_I: return OpCode::CMP_LT;
+            case OpCode::CMP_GE_I: return OpCode::CMP_GE;
+            case OpCode::CMP_LE_I: return OpCode::CMP_LE;
+            case OpCode::NEG_I: return OpCode::NEG;
+            default: return op;
+        }
+    }
+
     bool containsOp(const BytecodeChunk& chunk, OpCode op) {
         for (const auto& instr : chunk.code)
-            if (instr.op == op)
+            if (canonicalOp(instr.op) == op)
                 return true;
 
         return false;
@@ -751,7 +768,7 @@ namespace {
     int countOp(const BytecodeChunk& chunk, OpCode op) {
         int total = 0;
         for (const auto& instr : chunk.code)
-            if (instr.op == op)
+            if (canonicalOp(instr.op) == op)
                 ++total;
 
         return total;

--- a/tests/common/frontend/OptimizerTest.cpp
+++ b/tests/common/frontend/OptimizerTest.cpp
@@ -784,8 +784,6 @@ TEST(OptimizerTest, PassMaskDefaultsToEveryPassEnabled) {
     EXPECT_EQ(optimizer.enabledPasses(), Optimizer::allPasses);
 }
 
-// ---- dead store elimination ---------------------------------------------------
-
 namespace {
     int countOp(const BytecodeChunk& chunk, OpCode op) {
         int total = 0;
@@ -912,8 +910,6 @@ TEST(OptimizerTest, RejectedFoldKeepsItsOperandsOnTheStack) {
     EXPECT_NE(program.diagnostics.getErrorMessage().find("Modulo requires integral types"), std::string::npos);
 }
 
-// ---- common subexpression elimination ----------------------------------------
-
 namespace {
     int countOpEverywhere(const BytecodeChunk& chunk, OpCode op) {
         int total = countOp(chunk, op);
@@ -969,9 +965,6 @@ TEST(OptimizerTest, CSEStaysCorrectAcrossCalls) {
     EXPECT_EQ(VM::valueToString(vm.run(program.chunk, {})), "8");
 }
 
-// Rewriting inside a loop body shifts the distance between a jump and its target,
-// so the relative offsets of the back edge and the exit branch have to survive the
-// rewrite as well.
 TEST(OptimizerTest, CSEInsideLoopKeepsJumpOffsets) {
     const std::string source =
         "func f(a: int, b: int, n: int) -> int {\n"

--- a/tests/common/frontend/StdlibTest.cpp
+++ b/tests/common/frontend/StdlibTest.cpp
@@ -14,8 +14,7 @@ TEST(StdlibArrayTest, PushReturnsNewLength) {
 }
 
 TEST(StdlibArrayTest, ValueMethodOnDynamicTarget) {
-    // Method call on a dynamically typed target (member read): the dispatch is
-    // deferred to the VM, which selects "Array"/"String" by the runtime value.
+    
     EXPECT_EQ(eval("class Holder { public: value = []; } let h = new Holder(); h.value.push(1); h.value.push(2); h.value"), "[1, 2]");
     EXPECT_EQ(eval("class Holder { public: value = []; } let h = new Holder(); let v = h.value; v.push(7); v.length()"), "1");
     EXPECT_EQ(eval("class Holder { public: value = \"a,b\"; } let h = new Holder(); h.value.split(\",\")[1]"), "b");

--- a/tests/common/frontend/TypeSystemTest.cpp
+++ b/tests/common/frontend/TypeSystemTest.cpp
@@ -39,8 +39,7 @@ TEST(TypeSystemTest, OptionalEmptyAccessErrors) {
 }
 
 TEST(TypeSystemTest, NoneOnlyInOptionalContext) {
-    // Dynamic variables may hold 'None' (needed for '??' / '?.' semantics);
-    // typed variables still reject it.
+    
     EXPECT_EQ(eval("let c = None; c ?? 1"), "1");
     EXPECT_THROW(eval("let c: int = None;"), std::runtime_error);
     EXPECT_THROW(eval("func f() -> int { return None; } f()"), std::runtime_error);


### PR DESCRIPTION
# Optimizer passes and VM execution-layer performance work

## Summary

Adds a set of optimizer passes to the IR pipeline and speeds up the bytecode VM's hot execution paths. The frontend now runs five configurable passes over a fixed-point loop, and the interpreter skips the generic value-dispatch and per-call allocation costs that dominated integer and call-heavy workloads.

## Optimizer

- **Loop-invariant code motion** (`LICMPass`): builds a control-flow graph, hoists the longest invariant prefix of a loop header into a preheader, feeds each iteration with a single `DUP`, and balances the single exit with a `POP`. Relative jump targets are re-resolved after every rewrite.
- **Common subexpression elimination** (`CSEPass`): value-numbers pure expressions per basic block and lazily spills them into `DUP_STORE_SLOT`/`LOAD_SLOT` slots only when actually reused. A regression test covers CSE firing inside a loop body, which previously corrupted relative back-edge offsets.
- **Dead store elimination** (`DeadStorePass`): drops `STORE_VAR`/`STORE_SLOT` writes that a later store overwrites before any read.
- **Field-access inline cache**: `LOAD_FIELD`/`STORE_FIELD` resolve the field slot once per instruction site instead of on every access.
- **Constant folding over native value methods**: pure stdlib value methods fold at compile time; a fold that is rejected restores its operands.
- **OpCode-based dispatch** for arithmetic/comparison/unary operators, replacing string-keyed dispatch.
- **`canWriteVariables` fix**: covers the by-name and native-call opcodes so constant propagation invalidates correctly across them.
- **By-name `for-in` fix**: the element call now passes the receiver last.

## VM execution layer

- **Integer fast path**: when both operands are `int`, arithmetic and comparisons run directly on the stack instead of going through `applyArithmetic`/`applyComparison` — no per-instruction operator `std::string`, no `std::variant` visit.
- **Argument vectors removed**: function/method calls pop arguments straight into the callee locals in reverse stack order instead of building a temporary `std::vector`.
- **Frame arena**: all active call frames share one contiguous `localPool`; a frame stores a base offset and the pool grows on entry and shrinks on return, so warm call paths no longer touch the allocator.
- **Move semantics on the operand stack**: `pop`/`push` hand values around by move.

## Benchmarks

Measured with a repo-external harness. Geometric mean over the bundled micro-benchmarks is roughly **1.33x** (peak 1.5x) with all passes enabled. On a call-heavy workload, recursive `fib(35)` drops from **6.79 s to 4.72 s** (~1.44x), with per-call heap allocation eliminated entirely.

## Testing

- `442 / 445` gtest tests pass; the 3 remaining `StdlibObservableTest` failures are pre-existing and unrelated (they require `ll::ui::Observable`, which is absent from the harness).
- Corpus equivalence (52 scripts): pass.
- Loop stress, four-way comparison (59 scripts): pass.
