### PR TITLE
PR: Clean up MIR pipeline comments, remove integer-specialized opcodes, fix constant folding and VM arithmetic, and restore MIR serialization

### DIFF
--- a/src/LOICollectionA/frontend/Lexer.cpp
+++ b/src/LOICollectionA/frontend/Lexer.cpp
@@ -107,7 +107,11 @@ namespace LOICollection::frontend {
             if (std::isdigit(static_cast<unsigned char>(currentChar))) return parseNumber();
             if (std::strchr("=><!&|-", currentChar)) return parseOperator();
 
-            return parseIdentifier();
+            if (std::isalnum(static_cast<unsigned char>(currentChar)) || currentChar == '_')
+                return parseIdentifier();
+
+            diagnostics.addError({line, column, position}, "Unexpected character");
+            return makeToken(TokenType::TOKEN_OP);
         }
         
         return { TokenType::TOKEN_EOF, "", {line, column, position} };

--- a/src/LOICollectionA/frontend/Parser.h
+++ b/src/LOICollectionA/frontend/Parser.h
@@ -19,6 +19,16 @@ namespace LOICollection::frontend {
         DiagnosticEngine& diagnostics;
 
         size_t declarativeDepth = 0;
+        size_t parseDepth = 0;
+
+        static constexpr size_t kMaxParseDepth = 1024;
+
+        struct DepthGuard {
+            size_t& depth;
+
+            explicit DepthGuard(size_t& d) : depth(d) { ++depth; }
+            ~DepthGuard() { --depth; }
+        };
 
     public:
         LOICOLLECTION_A_API   Parser(Lexer& l, DiagnosticEngine& diag);

--- a/src/LOICollectionA/frontend/ScriptLoader.cpp
+++ b/src/LOICollectionA/frontend/ScriptLoader.cpp
@@ -55,6 +55,43 @@ namespace LOICollection::frontend {
             }
         }
 
+        std::string typeExprName(const TypeExpr& expr) {
+            std::string out = expr.name;
+            if (expr.args.empty())
+                return out;
+
+            out += '<';
+            for (size_t i = 0; i < expr.args.size(); ++i) {
+                if (i != 0)
+                    out += ',';
+
+                out += typeExprName(expr.args[i]);
+            }
+
+            return out + '>';
+        }
+
+        std::string definitionKey(ASTNode& node) {
+            const std::string* name = definitionName(node);
+            if (!name)
+                return {};
+
+            if (node.getType() != ASTNode::Type::FunctionDef)
+                return *name;
+
+            auto& decl = static_cast<FunctionDefNode&>(node).decl;
+
+            std::string key = *name + '(';
+            for (size_t i = 0; i < decl.params.size(); ++i) {
+                if (i != 0)
+                    key += ',';
+
+                key += decl.params[i].hasType ? typeExprName(decl.params[i].typeExpr) : "?";
+            }
+
+            return key + ')';
+        }
+
         std::string displayName(const std::string& path, const std::string& rootDir) {
             std::error_code ec;
             auto relative = std::filesystem::relative(path, rootDir, ec);
@@ -175,17 +212,15 @@ namespace LOICollection::frontend {
                 if (const std::string* name = definitionName(*part)) {
                     SourceLocation loc = definitionLoc(*part);
 
-                    auto existing = definedAt.find(*name);
-                    if (existing != definedAt.end()) {
+                    auto [slot, inserted] = definedAt.emplace(definitionKey(*part), std::make_pair(path, loc.line));
+                    if (!inserted) {
                         diagnostics.addError(loc,
                             "Definition '" + *name + "' from '" + displayName(path, root) +
                             "' (line " + std::to_string(loc.line) +
-                            ") conflicts with the one in '" + displayName(existing->second.first, root) +
-                            "' (line " + std::to_string(existing->second.second) + ")");
+                            ") conflicts with the one in '" + displayName(slot->second.first, root) +
+                            "' (line " + std::to_string(slot->second.second) + ")");
                         return std::nullopt;
                     }
-
-                    definedAt.emplace(*name, std::make_pair(path, loc.line));
                 }
 
                 nodes.push_back(std::move(part));

--- a/src/LOICollectionA/frontend/ir/Compiler.cpp
+++ b/src/LOICollectionA/frontend/ir/Compiler.cpp
@@ -899,7 +899,10 @@ namespace LOICollection::frontend::ir {
             if (hint >= 0 && i + 1 == node.parts.size())
                 this->dstHint = hint;
 
-            node.parts[i]->accept(*this);
+            ASTNode& part = *node.parts[i];
+            part.accept(*this);
+            this->lastPartWasDeclaration = part.getType() == ASTNode::Type::Assignment &&
+                static_cast<AssignmentNode&>(part).isDeclaration;
         }
 
         this->lastResultReg = this->finishHint(hint, this->lastResultReg, {});

--- a/src/LOICollectionA/frontend/ir/Compiler.cpp
+++ b/src/LOICollectionA/frontend/ir/Compiler.cpp
@@ -286,8 +286,11 @@ namespace LOICollection::frontend::ir {
     }
 
     int Compiler::emitLoad(const std::string& name, const SourceLocation& loc) {
-        if (auto slot = this->resolveSlot(name))
-            return *slot;
+        if (auto slot = this->resolveSlot(name)) {
+            const int dst = this->takeDst();
+            this->current.get().emit(MirOp::LOAD_SLOT, *slot, dst, -1, -1, loc);
+            return dst;
+        }
 
         const int dst = this->takeDst();
         this->current.get().emit(MirOp::LOAD_VAR, this->addConstant(name), dst, -1, -1, loc);
@@ -1330,6 +1333,8 @@ namespace LOICollection::frontend::ir {
         if (node.decl.body) {
             this->predeclareLocals(*node.decl.body);
             lastReg = this->compilePart(*node.decl.body);
+            if (this->lastPartWasDeclaration)
+                lastReg = -1;
         }
 
         this->current.get().emit(MirOp::RETURN, 0, -1, lastReg, -1);
@@ -1424,6 +1429,8 @@ namespace LOICollection::frontend::ir {
         if (node.decl.body) {
             this->predeclareLocals(*node.decl.body);
             lastReg = this->compilePart(*node.decl.body);
+            if (this->lastPartWasDeclaration)
+                lastReg = -1;
         }
 
         this->current.get().emit(MirOp::RETURN, 0, -1, lastReg, -1);

--- a/src/LOICollectionA/frontend/ir/Compiler.h
+++ b/src/LOICollectionA/frontend/ir/Compiler.h
@@ -65,6 +65,7 @@ namespace LOICollection::frontend::ir {
 
         int lastResultReg = -1;
         int dstHint = -1;
+        bool lastPartWasDeclaration = false;
 
         void visit(ValueNode& node) override;
         void visit(VariableNode& node) override;

--- a/src/LOICollectionA/frontend/ir/MirSerializer.cpp
+++ b/src/LOICollectionA/frontend/ir/MirSerializer.cpp
@@ -86,6 +86,7 @@ namespace LOICollection::frontend::ir {
         constexpr uint8_t CONST_ARRAY = 5;
 
         constexpr size_t kDigestSize = 32;
+        constexpr size_t kMaxDepth = 64;
 
         constexpr uint8_t TYPEKIND_UNKNOWN = 0;
         constexpr uint8_t TYPEKIND_INT = 1;
@@ -115,7 +116,10 @@ namespace LOICollection::frontend::ir {
                 writeTypeInfo(writer, *type.optionalInner);
         }
 
-        bool readTypeInfo(Reader& reader, TypeInfo& type) {
+        bool readTypeInfo(Reader& reader, TypeInfo& type, size_t depth = 0) {
+            if (depth > kMaxDepth)
+                return false;
+
             uint8_t kind = 0;
             if (!reader.u8(kind) || kind > TYPEKIND_NONE)
                 return false;
@@ -132,7 +136,7 @@ namespace LOICollection::frontend::ir {
             type.variantOptions.reserve(optionCount);
             for (uint32_t i = 0; i < optionCount; ++i) {
                 TypeInfo option;
-                if (!readTypeInfo(reader, option))
+                if (!readTypeInfo(reader, option, depth + 1))
                     return false;
 
                 type.variantOptions.push_back(std::move(option));
@@ -144,7 +148,7 @@ namespace LOICollection::frontend::ir {
 
             if (hasInner != 0) {
                 type.optionalInner = std::make_shared<TypeInfo>();
-                if (!readTypeInfo(reader, *type.optionalInner))
+                if (!readTypeInfo(reader, *type.optionalInner, depth + 1))
                     return false;
             } else {
                 type.optionalInner.reset();
@@ -172,7 +176,11 @@ namespace LOICollection::frontend::ir {
                     writer.u8(std::get<bool>(value) ? 1 : 0);
                     return true;
                 case 6: {
-                    const auto& elements = std::get<ArrayRef>(value)->elements;
+                    const auto& array = std::get<ArrayRef>(value);
+                    if (!array)
+                        return false;
+
+                    const auto& elements = array->elements;
                     if (elements.size() > 0xFFFFFFFFull)
                         return false;
 
@@ -192,7 +200,10 @@ namespace LOICollection::frontend::ir {
             }
         }
 
-        bool readValue(Reader& reader, ValueNode::ValueType& value) {
+        bool readValue(Reader& reader, ValueNode::ValueType& value, size_t depth = 0) {
+            if (depth > kMaxDepth)
+                return false;
+
             uint8_t tag = 0;
             if (!reader.u8(tag))
                 return false;
@@ -238,7 +249,7 @@ namespace LOICollection::frontend::ir {
                     elements->elements.reserve(count);
                     for (uint32_t i = 0; i < count; ++i) {
                         ValueNode::ValueType element;
-                        if (!readValue(reader, element)) return false;
+                        if (!readValue(reader, element, depth + 1)) return false;
 
                         elements->elements.push_back(std::move(element));
                     }
@@ -279,7 +290,7 @@ namespace LOICollection::frontend::ir {
 
         bool writeChunk(Writer& writer, const MirChunk& chunk);
 
-        bool readChunk(Reader& reader, MirChunk& chunk);
+        bool readChunk(Reader& reader, MirChunk& chunk, size_t depth = 0);
 
         void writeInstruction(Writer& writer, const MirInstr& instr) {
             writer.u8(static_cast<uint8_t>(instr.op));
@@ -330,7 +341,10 @@ namespace LOICollection::frontend::ir {
                 writeDebugInfo(writer, *body);
         }
 
-        bool readDebugInfo(Reader& reader, MirChunk& chunk) {
+        bool readDebugInfo(Reader& reader, MirChunk& chunk, size_t depth = 0) {
+            if (depth > kMaxDepth)
+                return false;
+
             for (auto& instr : chunk.code) {
                 uint64_t line = 0;
                 uint64_t column = 0;
@@ -343,7 +357,7 @@ namespace LOICollection::frontend::ir {
             }
 
             for (auto& body : chunk.methodBodies)
-                if (!readDebugInfo(reader, *body))
+                if (!readDebugInfo(reader, *body, depth + 1))
                     return false;
 
             return true;
@@ -584,13 +598,16 @@ namespace LOICollection::frontend::ir {
 
             writer.u32(static_cast<uint32_t>(chunk.methodBodies.size()));
             for (const auto& body : chunk.methodBodies)
-                if (!writeChunk(writer, *body))
+                if (!body || !writeChunk(writer, *body))
                     return false;
 
             return true;
         }
 
-        bool readChunk(Reader& reader, MirChunk& chunk) {
+        bool readChunk(Reader& reader, MirChunk& chunk, size_t depth) {
+            if (depth > kMaxDepth)
+                return false;
+
             if (!(readVector<MirInstr>(reader, chunk.code, [](Reader& r, MirInstr& instr) -> bool {
                 return readInstruction(r, instr);
             })
@@ -635,7 +652,7 @@ namespace LOICollection::frontend::ir {
             chunk.methodBodies.clear();
             for (uint32_t i = 0; i < bodyCount; ++i) {
                 auto body = std::make_unique<MirChunk>();
-                if (!readChunk(reader, *body))
+                if (!readChunk(reader, *body, depth + 1))
                     return false;
 
                 chunk.methodBodies.push_back(std::move(body));

--- a/src/LOICollectionA/frontend/ir/MirSerializer.cpp
+++ b/src/LOICollectionA/frontend/ir/MirSerializer.cpp
@@ -1,0 +1,838 @@
+#include <cstring>
+
+#include "LOICollectionA/frontend/ir/MirSerializer.h"
+
+#include "LOICollectionA/utils/core/Sha256.h"
+
+namespace LOICollection::frontend::ir {
+    namespace {
+        class Writer {
+        public:
+            void raw(const void* data, size_t size) {
+                const auto* bytes = static_cast<const char*>(data);
+                this->buffer.insert(this->buffer.end(), bytes, bytes + size);
+            }
+
+            void u8(uint8_t value) { this->raw(&value, 1); }
+
+            void u32(uint32_t value) { this->raw(&value, sizeof(value)); }
+
+            void i32(int32_t value) { this->raw(&value, sizeof(value)); }
+
+            void f32(float value) { this->raw(&value, sizeof(value)); }
+
+            void u64(uint64_t value) { this->raw(&value, sizeof(value)); }
+
+            void str(const std::string& value) {
+                this->u32(static_cast<uint32_t>(value.size()));
+                this->raw(value.data(), value.size());
+            }
+
+            std::string take() { return std::move(this->buffer); }
+
+        private:
+            std::string buffer;
+        };
+
+        class Reader {
+        public:
+            explicit Reader(const std::string& blob) : blob(blob) {}
+
+            bool raw(void* out, size_t size) {
+                if (this->pos + size > this->blob.size())
+                    return false;
+
+                std::memcpy(out, this->blob.data() + this->pos, size);
+                this->pos += size;
+                return true;
+            }
+
+            bool u8(uint8_t& value) { return this->raw(&value, 1); }
+
+            bool u32(uint32_t& value) { return this->raw(&value, sizeof(value)); }
+
+            bool i32(int32_t& value) { return this->raw(&value, sizeof(value)); }
+
+            bool f32(float& value) { return this->raw(&value, sizeof(value)); }
+
+            bool u64(uint64_t& value) { return this->raw(&value, sizeof(value)); }
+
+            bool str(std::string& value) {
+                uint32_t size = 0;
+                if (!this->u32(size) || this->pos + size > this->blob.size())
+                    return false;
+
+                value.assign(this->blob, this->pos, size);
+                this->pos += size;
+                return true;
+            }
+
+            bool done() const { return this->pos == this->blob.size(); }
+
+            size_t position() const { return this->pos; }
+
+            size_t remaining() const { return this->blob.size() - this->pos; }
+
+        private:
+            const std::string& blob;
+            size_t pos = 0;
+        };
+
+        constexpr uint8_t CONST_INT = 0;
+        constexpr uint8_t CONST_FLOAT = 1;
+        constexpr uint8_t CONST_STRING = 2;
+        constexpr uint8_t CONST_BOOL = 3;
+        constexpr uint8_t CONST_NONE = 4;
+        constexpr uint8_t CONST_ARRAY = 5;
+
+        constexpr size_t kDigestSize = 32;
+
+        constexpr uint8_t TYPEKIND_UNKNOWN = 0;
+        constexpr uint8_t TYPEKIND_INT = 1;
+        constexpr uint8_t TYPEKIND_FLOAT = 2;
+        constexpr uint8_t TYPEKIND_STRING = 3;
+        constexpr uint8_t TYPEKIND_BOOL = 4;
+        constexpr uint8_t TYPEKIND_OBJECT = 5;
+        constexpr uint8_t TYPEKIND_FUNCTION = 6;
+        constexpr uint8_t TYPEKIND_VOID = 7;
+        constexpr uint8_t TYPEKIND_ARRAY = 8;
+        constexpr uint8_t TYPEKIND_VARIANT = 9;
+        constexpr uint8_t TYPEKIND_OPTIONAL = 10;
+        constexpr uint8_t TYPEKIND_GENERIC = 11;
+        constexpr uint8_t TYPEKIND_NONE = 12;
+
+        void writeTypeInfo(Writer& writer, const TypeInfo& type) {
+            writer.u8(static_cast<uint8_t>(type.kind));
+            writer.str(type.className);
+            writer.str(type.typeVar);
+
+            writer.u32(static_cast<uint32_t>(type.variantOptions.size()));
+            for (const auto& option : type.variantOptions)
+                writeTypeInfo(writer, option);
+
+            writer.u8(type.optionalInner ? 1 : 0);
+            if (type.optionalInner)
+                writeTypeInfo(writer, *type.optionalInner);
+        }
+
+        bool readTypeInfo(Reader& reader, TypeInfo& type) {
+            uint8_t kind = 0;
+            if (!reader.u8(kind) || kind > TYPEKIND_NONE)
+                return false;
+
+            type.kind = static_cast<TypeKind>(kind);
+            if (!reader.str(type.className) || !reader.str(type.typeVar))
+                return false;
+
+            uint32_t optionCount = 0;
+            if (!reader.u32(optionCount) || optionCount > reader.remaining())
+                return false;
+
+            type.variantOptions.clear();
+            type.variantOptions.reserve(optionCount);
+            for (uint32_t i = 0; i < optionCount; ++i) {
+                TypeInfo option;
+                if (!readTypeInfo(reader, option))
+                    return false;
+
+                type.variantOptions.push_back(std::move(option));
+            }
+
+            uint8_t hasInner = 0;
+            if (!reader.u8(hasInner))
+                return false;
+
+            if (hasInner != 0) {
+                type.optionalInner = std::make_shared<TypeInfo>();
+                if (!readTypeInfo(reader, *type.optionalInner))
+                    return false;
+            } else {
+                type.optionalInner.reset();
+            }
+
+            return true;
+        }
+
+        bool writeValue(Writer& writer, const ValueNode::ValueType& value) {
+            switch (value.index()) {
+                case CONST_INT:
+                    writer.u8(CONST_INT);
+                    writer.i32(std::get<int>(value));
+                    return true;
+                case CONST_FLOAT:
+                    writer.u8(CONST_FLOAT);
+                    writer.f32(std::get<float>(value));
+                    return true;
+                case CONST_STRING:
+                    writer.u8(CONST_STRING);
+                    writer.str(std::get<std::string>(value));
+                    return true;
+                case CONST_BOOL:
+                    writer.u8(CONST_BOOL);
+                    writer.u8(std::get<bool>(value) ? 1 : 0);
+                    return true;
+                case 6: {
+                    const auto& elements = std::get<ArrayRef>(value)->elements;
+                    if (elements.size() > 0xFFFFFFFFull)
+                        return false;
+
+                    writer.u8(CONST_ARRAY);
+                    writer.u32(static_cast<uint32_t>(elements.size()));
+                    for (const auto& element : elements)
+                        if (!writeValue(writer, element))
+                            return false;
+
+                    return true;
+                }
+                case 7:
+                    writer.u8(CONST_NONE);
+                    return true;
+                default:
+                    return false;
+            }
+        }
+
+        bool readValue(Reader& reader, ValueNode::ValueType& value) {
+            uint8_t tag = 0;
+            if (!reader.u8(tag))
+                return false;
+
+            switch (tag) {
+                case CONST_INT: {
+                    int32_t raw = 0;
+                    if (!reader.i32(raw)) return false;
+
+                    value = static_cast<int>(raw);
+                    return true;
+                }
+                case CONST_FLOAT: {
+                    float raw = 0;
+                    if (!reader.f32(raw)) return false;
+
+                    value = raw;
+                    return true;
+                }
+                case CONST_STRING: {
+                    std::string raw;
+                    if (!reader.str(raw)) return false;
+
+                    value = std::move(raw);
+                    return true;
+                }
+                case CONST_BOOL: {
+                    uint8_t raw = 0;
+                    if (!reader.u8(raw)) return false;
+
+                    value = raw != 0;
+                    return true;
+                }
+                case CONST_NONE:
+                    value = std::monostate{};
+                    return true;
+                case CONST_ARRAY: {
+                    uint32_t count = 0;
+                    if (!reader.u32(count) || count > reader.remaining())
+                        return false;
+
+                    auto elements = std::make_shared<ArrayValue>();
+                    elements->elements.reserve(count);
+                    for (uint32_t i = 0; i < count; ++i) {
+                        ValueNode::ValueType element;
+                        if (!readValue(reader, element)) return false;
+
+                        elements->elements.push_back(std::move(element));
+                    }
+
+                    value = std::move(elements);
+                    return true;
+                }
+                default:
+                    return false;
+            }
+        }
+
+        template <typename T>
+        void writeVector(Writer& writer, const std::vector<T>& items, auto&& write) {
+            writer.u32(static_cast<uint32_t>(items.size()));
+            for (const auto& item : items)
+                write(writer, item);
+        }
+
+        template <typename T>
+        bool readVector(Reader& reader, std::vector<T>& items, auto&& read) {
+            uint32_t count = 0;
+            if (!reader.u32(count) || count > reader.remaining())
+                return false;
+
+            items.clear();
+            items.reserve(count);
+            for (uint32_t i = 0; i < count; ++i) {
+                T item{};
+                if (!read(reader, item))
+                    return false;
+
+                items.push_back(std::move(item));
+            }
+
+            return true;
+        }
+
+        bool writeChunk(Writer& writer, const MirChunk& chunk);
+
+        bool readChunk(Reader& reader, MirChunk& chunk);
+
+        void writeInstruction(Writer& writer, const MirInstr& instr) {
+            writer.u8(static_cast<uint8_t>(instr.op));
+            writer.i32(instr.operand);
+            writer.i32(instr.dst);
+            writer.i32(instr.src1);
+            writer.i32(instr.src2);
+            writer.i32(instr.src3);
+            writer.i32(instr.imm);
+            writeTypeInfo(writer, instr.type);
+            writer.u64(instr.loc.line);
+            writer.u64(instr.loc.column);
+            writer.u64(instr.loc.offset);
+        }
+
+        bool readInstruction(Reader& reader, MirInstr& instr) {
+            uint8_t op = 0;
+            if (!reader.u8(op) || op >= static_cast<uint8_t>(MirOp::COUNT))
+                return false;
+
+            instr.op = static_cast<MirOp>(op);
+            if (!reader.i32(instr.operand) || !reader.i32(instr.dst)
+                || !reader.i32(instr.src1) || !reader.i32(instr.src2)
+                || !reader.i32(instr.src3) || !reader.i32(instr.imm))
+                return false;
+
+            if (!readTypeInfo(reader, instr.type))
+                return false;
+
+            uint64_t line = 0;
+            uint64_t column = 0;
+            uint64_t offset = 0;
+            if (!reader.u64(line) || !reader.u64(column) || !reader.u64(offset))
+                return false;
+
+            instr.loc = SourceLocation(line, column, offset);
+            return true;
+        }
+
+        void writeDebugInfo(Writer& writer, const MirChunk& chunk) {
+            for (const auto& instr : chunk.code) {
+                writer.u64(instr.loc.line);
+                writer.u64(instr.loc.column);
+                writer.u64(instr.loc.offset);
+            }
+
+            for (const auto& body : chunk.methodBodies)
+                writeDebugInfo(writer, *body);
+        }
+
+        bool readDebugInfo(Reader& reader, MirChunk& chunk) {
+            for (auto& instr : chunk.code) {
+                uint64_t line = 0;
+                uint64_t column = 0;
+                uint64_t offset = 0;
+
+                if (!reader.u64(line) || !reader.u64(column) || !reader.u64(offset))
+                    return false;
+
+                instr.loc = SourceLocation(line, column, offset);
+            }
+
+            for (auto& body : chunk.methodBodies)
+                if (!readDebugInfo(reader, *body))
+                    return false;
+
+            return true;
+        }
+
+        size_t countInstructions(const MirChunk& chunk) {
+            size_t total = chunk.code.size();
+            for (const auto& body : chunk.methodBodies)
+                total += countInstructions(*body);
+
+            return total;
+        }
+
+        void writeFuncMeta(Writer& writer, const FuncMeta& meta) {
+            writer.str(meta.name);
+            writer.i32(meta.argCount);
+        }
+
+        bool readFuncMeta(Reader& reader, FuncMeta& meta) {
+            return reader.str(meta.name) && reader.i32(meta.argCount);
+        }
+
+        void writeMacroMeta(Writer& writer, const MacroMeta& meta) {
+            writer.str(meta.name);
+            writer.i32(meta.argCount);
+        }
+
+        bool readMacroMeta(Reader& reader, MacroMeta& meta) {
+            return reader.str(meta.name) && reader.i32(meta.argCount);
+        }
+
+        void writeStrings(Writer& writer, const std::vector<std::string>& items) {
+            writer.u32(static_cast<uint32_t>(items.size()));
+            for (const auto& item : items)
+                writer.str(item);
+        }
+
+        bool readStrings(Reader& reader, std::vector<std::string>& items) {
+            return readVector<std::string>(reader, items, [](Reader& r, std::string& s) -> bool {
+                return r.str(s);
+            });
+        }
+
+        bool writeValues(Writer& writer, const std::vector<ValueNode::ValueType>& items) {
+            writer.u32(static_cast<uint32_t>(items.size()));
+            for (const auto& item : items)
+                if (!writeValue(writer, item))
+                    return false;
+
+            return true;
+        }
+
+        bool readValues(Reader& reader, std::vector<ValueNode::ValueType>& items) {
+            return readVector<ValueNode::ValueType>(reader, items, [](Reader& r, ValueNode::ValueType& v) -> bool {
+                return readValue(r, v);
+            });
+        }
+
+        void writeBools(Writer& writer, const std::vector<bool>& items) {
+            writer.u32(static_cast<uint32_t>(items.size()));
+            for (bool item : items)
+                writer.u8(item ? 1 : 0);
+        }
+
+        bool readBools(Reader& reader, std::vector<bool>& items) {
+            return readVector<bool>(reader, items, [](Reader& r, bool& b) -> bool {
+                uint8_t raw = 0;
+                if (!r.u8(raw)) return false;
+
+                b = raw != 0;
+                return true;
+            });
+        }
+
+        void writeInts(Writer& writer, const std::vector<int>& items) {
+            writer.u32(static_cast<uint32_t>(items.size()));
+            for (int item : items)
+                writer.i32(item);
+        }
+
+        bool readInts(Reader& reader, std::vector<int>& items) {
+            return readVector<int>(reader, items, [](Reader& r, int& v) -> bool {
+                int32_t raw = 0;
+                if (!r.i32(raw)) return false;
+
+                v = raw;
+                return true;
+            });
+        }
+
+        bool writeClassMeta(Writer& writer, const ClassMeta& meta) {
+            writer.str(meta.name);
+            writer.i32(meta.baseClassIndex);
+
+            writeStrings(writer, meta.fieldNames);
+            if (!writeValues(writer, meta.defaults))
+                return false;
+
+            writeBools(writer, meta.hasDefault);
+
+            writeStrings(writer, meta.staticFieldNames);
+            if (!writeValues(writer, meta.staticDefaults))
+                return false;
+
+            writeBools(writer, meta.staticHasDefault);
+
+            writer.i32(meta.constructorIndex);
+            writeInts(writer, meta.methods);
+            writeStrings(writer, meta.methodSignatures);
+            writeInts(writer, meta.staticMethods);
+            writeStrings(writer, meta.staticMethodSignatures);
+            writeInts(writer, meta.ancestorIndices);
+            return true;
+        }
+
+        bool readClassMeta(Reader& reader, ClassMeta& meta) {
+            return reader.str(meta.name) && reader.i32(meta.baseClassIndex)
+                && readStrings(reader, meta.fieldNames)
+                && readValues(reader, meta.defaults)
+                && readBools(reader, meta.hasDefault)
+                && readStrings(reader, meta.staticFieldNames)
+                && readValues(reader, meta.staticDefaults)
+                && readBools(reader, meta.staticHasDefault)
+                && reader.i32(meta.constructorIndex)
+                && readInts(reader, meta.methods)
+                && readStrings(reader, meta.methodSignatures)
+                && readInts(reader, meta.staticMethods)
+                && readStrings(reader, meta.staticMethodSignatures)
+                && readInts(reader, meta.ancestorIndices);
+        }
+
+        void writeMethodMeta(Writer& writer, const MethodMeta& meta) {
+            writer.str(meta.name);
+            writer.i32(meta.argCount);
+            writer.i32(meta.classIndex);
+            writer.i32(meta.bodyIndex);
+        }
+
+        bool readMethodMeta(Reader& reader, MethodMeta& meta) {
+            return reader.str(meta.name)
+                && reader.i32(meta.argCount)
+                && reader.i32(meta.classIndex)
+                && reader.i32(meta.bodyIndex);
+        }
+
+        void writeNativeCallMeta(Writer& writer, const NativeCallMeta& meta) {
+            writer.str(meta.className);
+            writer.str(meta.name);
+            writer.i32(meta.argCount);
+            writer.u8(meta.isStatic ? 1 : 0);
+        }
+
+        bool readNativeCallMeta(Reader& reader, NativeCallMeta& meta) {
+            uint8_t isStatic = 0;
+            if (!reader.str(meta.className) || !reader.str(meta.name) || !reader.i32(meta.argCount) || !reader.u8(isStatic))
+                return false;
+
+            meta.isStatic = isStatic != 0;
+            return true;
+        }
+
+        void writeVirtualCallMeta(Writer& writer, const VirtualCallMeta& meta) {
+            writer.i32(meta.classIndex);
+            writer.i32(meta.ordinal);
+            writer.i32(meta.argCount);
+        }
+
+        bool readVirtualCallMeta(Reader& reader, VirtualCallMeta& meta) {
+            return reader.i32(meta.classIndex) && reader.i32(meta.ordinal) && reader.i32(meta.argCount);
+        }
+
+        void writeByNameCallMeta(Writer& writer, const ByNameCallMeta& meta) {
+            writer.str(meta.methodName);
+            writer.i32(meta.argCount);
+        }
+
+        bool readByNameCallMeta(Reader& reader, ByNameCallMeta& meta) {
+            return reader.str(meta.methodName) && reader.i32(meta.argCount);
+        }
+
+        void writeSuperCallMeta(Writer& writer, const SuperCallMeta& meta) {
+            writer.i32(meta.constructorIndex);
+            writer.i32(meta.argCount);
+        }
+
+        bool readSuperCallMeta(Reader& reader, SuperCallMeta& meta) {
+            return reader.i32(meta.constructorIndex) && reader.i32(meta.argCount);
+        }
+
+        void writeLambdaMeta(Writer& writer, const LambdaMeta& meta) {
+            writer.i32(meta.bodyIndex);
+            writer.i32(meta.argCount);
+            writer.i32(meta.captureCount);
+        }
+
+        bool readLambdaMeta(Reader& reader, LambdaMeta& meta) {
+            return reader.i32(meta.bodyIndex) && reader.i32(meta.argCount) && reader.i32(meta.captureCount);
+        }
+
+        bool writeChunk(Writer& writer, const MirChunk& chunk) {
+            writeVector<MirInstr>(writer, chunk.code, [](Writer& w, const MirInstr& instr) {
+                writeInstruction(w, instr);
+            });
+            if (!writeValues(writer, chunk.constants))
+                return false;
+
+            writeVector<FuncMeta>(writer, chunk.functions, [](Writer& w, const FuncMeta& meta) {
+                writeFuncMeta(w, meta);
+            });
+            writeVector<MacroMeta>(writer, chunk.macros, [](Writer& w, const MacroMeta& meta) {
+                writeMacroMeta(w, meta);
+            });
+            writer.u32(static_cast<uint32_t>(chunk.classes.size()));
+            for (const auto& cls : chunk.classes)
+                if (!writeClassMeta(writer, cls))
+                    return false;
+
+            writeVector<MethodMeta>(writer, chunk.methods, [](Writer& w, const MethodMeta& meta) {
+                writeMethodMeta(w, meta);
+            });
+            writeVector<NativeCallMeta>(writer, chunk.nativeCalls, [](Writer& w, const NativeCallMeta& meta) {
+                writeNativeCallMeta(w, meta);
+            });
+            writeVector<VirtualCallMeta>(writer, chunk.virtualCalls, [](Writer& w, const VirtualCallMeta& meta) {
+                writeVirtualCallMeta(w, meta);
+            });
+            writeVector<ByNameCallMeta>(writer, chunk.byNameCalls, [](Writer& w, const ByNameCallMeta& meta) {
+                writeByNameCallMeta(w, meta);
+            });
+            writeVector<SuperCallMeta>(writer, chunk.superCalls, [](Writer& w, const SuperCallMeta& meta) {
+                writeSuperCallMeta(w, meta);
+            });
+            writeVector<LambdaMeta>(writer, chunk.lambdas, [](Writer& w, const LambdaMeta& meta) {
+                writeLambdaMeta(w, meta);
+            });
+
+            writer.i32(chunk.slotCount);
+
+            writer.u32(static_cast<uint32_t>(chunk.methodBodies.size()));
+            for (const auto& body : chunk.methodBodies)
+                if (!writeChunk(writer, *body))
+                    return false;
+
+            return true;
+        }
+
+        bool readChunk(Reader& reader, MirChunk& chunk) {
+            if (!(readVector<MirInstr>(reader, chunk.code, [](Reader& r, MirInstr& instr) -> bool {
+                return readInstruction(r, instr);
+            })
+                && readValues(reader, chunk.constants)
+                && readVector<FuncMeta>(reader, chunk.functions, [](Reader& r, FuncMeta& meta) -> bool {
+                    return readFuncMeta(r, meta);
+                })
+                && readVector<MacroMeta>(reader, chunk.macros, [](Reader& r, MacroMeta& meta) -> bool {
+                    return readMacroMeta(r, meta);
+                })
+                && readVector<ClassMeta>(reader, chunk.classes, [](Reader& r, ClassMeta& meta) -> bool {
+                    return readClassMeta(r, meta);
+                })
+                && readVector<MethodMeta>(reader, chunk.methods, [](Reader& r, MethodMeta& meta) -> bool {
+                    return readMethodMeta(r, meta);
+                })
+                && readVector<NativeCallMeta>(reader, chunk.nativeCalls, [](Reader& r, NativeCallMeta& meta) -> bool {
+                    return readNativeCallMeta(r, meta);
+                })
+                && readVector<VirtualCallMeta>(reader, chunk.virtualCalls, [](Reader& r, VirtualCallMeta& meta) -> bool {
+                    return readVirtualCallMeta(r, meta);
+                })
+                && readVector<ByNameCallMeta>(reader, chunk.byNameCalls, [](Reader& r, ByNameCallMeta& meta) -> bool {
+                    return readByNameCallMeta(r, meta);
+                })
+                && readVector<SuperCallMeta>(reader, chunk.superCalls, [](Reader& r, SuperCallMeta& meta) -> bool {
+                    return readSuperCallMeta(r, meta);
+                })
+                && readVector<LambdaMeta>(reader, chunk.lambdas, [](Reader& r, LambdaMeta& meta) -> bool {
+                    return readLambdaMeta(r, meta);
+                })
+                && reader.i32(chunk.slotCount)))
+                return false;
+
+            if (chunk.slotCount < 0)
+                return false;
+
+            uint32_t bodyCount = 0;
+            if (!reader.u32(bodyCount))
+                return false;
+
+            chunk.methodBodies.clear();
+            for (uint32_t i = 0; i < bodyCount; ++i) {
+                auto body = std::make_unique<MirChunk>();
+                if (!readChunk(reader, *body))
+                    return false;
+
+                chunk.methodBodies.push_back(std::move(body));
+            }
+
+            return true;
+        }
+    }
+
+    std::optional<std::string> MirSerializer::serialize(
+        const MirChunk& chunk, const Header& header, std::string* bodyChecksum
+    ) {
+        if (header.abiFingerprint.size() != kDigestSize)
+            return std::nullopt;
+
+        Writer payload;
+        if (!writeChunk(payload, chunk))
+            return std::nullopt;
+
+        Writer writer;
+
+        writer.raw(MAGIC, sizeof(MAGIC));
+        writer.u32(FORMAT_VERSION);
+        writer.str(header.scriptId);
+        writer.raw(header.abiFingerprint.data(), header.abiFingerprint.size());
+        writer.u8(header.sourceHash ? 1 : 0);
+        if (header.sourceHash)
+            writer.raw(header.sourceHash->data(), header.sourceHash->size());
+
+        writer.u32(static_cast<uint32_t>(header.importHashes.size()));
+        for (const auto& hash : header.importHashes)
+            writer.raw(hash.data(), hash.size());
+
+        const std::string body = payload.take();
+        const std::string checksum = utils::Sha256::compute(body);
+        writer.raw(checksum.data(), checksum.size());
+        writer.raw(body.data(), body.size());
+
+        if (bodyChecksum)
+            *bodyChecksum = checksum;
+
+        return writer.take();
+    }
+
+    std::optional<MirChunk> MirSerializer::deserialize(
+        const std::string& blob, const Header& expected, std::string* bodyChecksum
+    ) {
+        Reader reader(blob);
+
+        char magic[sizeof(MAGIC)] = {};
+        uint32_t version = 0;
+        if (!reader.raw(magic, sizeof(magic)) || std::memcmp(magic, MAGIC, sizeof(MAGIC)) != 0)
+            return std::nullopt;
+
+        if (!reader.u32(version) || version != FORMAT_VERSION)
+            return std::nullopt;
+
+        std::string scriptId;
+        if (!reader.str(scriptId) || scriptId != expected.scriptId)
+            return std::nullopt;
+
+        std::string fingerprint(expected.abiFingerprint.size(), '\0');
+        if (fingerprint.empty()
+            || !reader.raw(fingerprint.data(), fingerprint.size())
+            || fingerprint != expected.abiFingerprint)
+            return std::nullopt;
+
+        uint8_t hasSource = 0;
+        if (!reader.u8(hasSource))
+            return std::nullopt;
+
+        std::string sourceHash(kDigestSize, '\0');
+        if (hasSource != 0 && !reader.raw(sourceHash.data(), sourceHash.size()))
+            return std::nullopt;
+
+        uint32_t importCount = 0;
+        if (!reader.u32(importCount) || importCount > reader.remaining() / kDigestSize)
+            return std::nullopt;
+
+        std::vector<std::string> importHashes;
+        importHashes.reserve(importCount);
+        for (uint32_t i = 0; i < importCount; ++i) {
+            std::string hash(kDigestSize, '\0');
+            if (!reader.raw(hash.data(), hash.size()))
+                return std::nullopt;
+
+            importHashes.push_back(std::move(hash));
+        }
+
+        if (expected.sourceHash
+            && (hasSource == 0 || sourceHash != *expected.sourceHash || importHashes != expected.importHashes))
+            return std::nullopt;
+
+        std::string checksum(kDigestSize, '\0');
+        if (!reader.raw(checksum.data(), checksum.size()))
+            return std::nullopt;
+
+        const size_t bodyOffset = reader.position();
+        const std::string body = blob.substr(bodyOffset);
+        if (utils::Sha256::compute(body) != checksum)
+            return std::nullopt;
+
+        if (bodyChecksum)
+            *bodyChecksum = checksum;
+
+        MirChunk chunk;
+        if (!readChunk(reader, chunk) || !reader.done())
+            return std::nullopt;
+
+        return chunk;
+    }
+
+    std::optional<MirSerializer::Header> MirSerializer::peekHeader(const std::string& blob) {
+        Reader reader(blob);
+
+        char magic[sizeof(MAGIC)] = {};
+        uint32_t version = 0;
+        if (!reader.raw(magic, sizeof(magic)) || std::memcmp(magic, MAGIC, sizeof(MAGIC)) != 0)
+            return std::nullopt;
+
+        if (!reader.u32(version) || version != FORMAT_VERSION)
+            return std::nullopt;
+
+        Header header;
+        if (!reader.str(header.scriptId))
+            return std::nullopt;
+
+        header.abiFingerprint.resize(kDigestSize);
+        if (!reader.raw(header.abiFingerprint.data(), header.abiFingerprint.size()))
+            return std::nullopt;
+
+        uint8_t hasSource = 0;
+        if (!reader.u8(hasSource))
+            return std::nullopt;
+
+        if (hasSource != 0) {
+            std::string sourceHash(kDigestSize, '\0');
+            if (!reader.raw(sourceHash.data(), sourceHash.size()))
+                return std::nullopt;
+
+            header.sourceHash = std::move(sourceHash);
+        }
+
+        uint32_t importCount = 0;
+        if (!reader.u32(importCount) || importCount > reader.remaining() / kDigestSize)
+            return std::nullopt;
+
+        header.importHashes.reserve(importCount);
+        for (uint32_t i = 0; i < importCount; ++i) {
+            std::string hash(kDigestSize, '\0');
+            if (!reader.raw(hash.data(), hash.size()))
+                return std::nullopt;
+
+            header.importHashes.push_back(std::move(hash));
+        }
+
+        return header;
+    }
+
+    std::optional<std::string> MirSerializer::serializeDebugInfo(
+        const MirChunk& chunk, const std::string& bodyChecksum
+    ) {
+        if (bodyChecksum.size() != kDigestSize)
+            return std::nullopt;
+
+        Writer writer;
+
+        writer.raw(DEBUG_MAGIC, sizeof(DEBUG_MAGIC));
+        writer.u32(FORMAT_VERSION);
+        writer.raw(bodyChecksum.data(), bodyChecksum.size());
+        writer.u64(countInstructions(chunk));
+        writeDebugInfo(writer, chunk);
+
+        return writer.take();
+    }
+
+    bool MirSerializer::attachDebugInfo(
+        MirChunk& chunk, const std::string& debugBlob, const std::string& bodyChecksum
+    ) {
+        Reader reader(debugBlob);
+
+        char magic[sizeof(DEBUG_MAGIC)] = {};
+        uint32_t version = 0;
+        if (!reader.raw(magic, sizeof(magic)) || std::memcmp(magic, DEBUG_MAGIC, sizeof(DEBUG_MAGIC)) != 0)
+            return false;
+
+        if (!reader.u32(version) || version != FORMAT_VERSION)
+            return false;
+
+        std::string checksum(bodyChecksum.size(), '\0');
+        if (checksum.empty() || !reader.raw(checksum.data(), checksum.size()) || checksum != bodyChecksum)
+            return false;
+
+        uint64_t count = 0;
+        if (!reader.u64(count) || count != countInstructions(chunk))
+            return false;
+
+        return readDebugInfo(reader, chunk) && reader.done();
+    }
+}

--- a/src/LOICollectionA/frontend/ir/MirSerializer.h
+++ b/src/LOICollectionA/frontend/ir/MirSerializer.h
@@ -1,0 +1,47 @@
+#pragma once
+
+#include <memory>
+#include <optional>
+#include <string>
+#include <vector>
+
+#include "LOICollectionA/base/Macro.h"
+
+#include "LOICollectionA/frontend/ir/Mir.h"
+
+namespace LOICollection::frontend::ir {
+    class MirSerializer {
+    public:
+        struct Header {
+            std::string scriptId;
+            std::string abiFingerprint;
+            std::optional<std::string> sourceHash;
+            std::vector<std::string> importHashes;
+        };
+
+        LOICOLLECTION_A_NDAPI static std::optional<std::string> serialize(
+            const MirChunk& chunk, const Header& header, std::string* bodyChecksum = nullptr
+        );
+
+        LOICOLLECTION_A_NDAPI static std::optional<MirChunk> deserialize(
+            const std::string& blob, const Header& expected, std::string* bodyChecksum = nullptr
+        );
+
+        LOICOLLECTION_A_NDAPI static std::optional<Header> peekHeader(const std::string& blob);
+
+        LOICOLLECTION_A_NDAPI static std::optional<std::string> serializeDebugInfo(
+            const MirChunk& chunk, const std::string& bodyChecksum
+        );
+
+        LOICOLLECTION_A_NDAPI static bool attachDebugInfo(
+            MirChunk& chunk, const std::string& debugBlob, const std::string& bodyChecksum
+        );
+
+    private:
+        MirSerializer() = default;
+
+        static constexpr char MAGIC[4] = { 'L', 'C', 'U', 'P' };
+        static constexpr char DEBUG_MAGIC[4] = { 'L', 'C', 'U', 'D' };
+        static constexpr uint32_t FORMAT_VERSION = 1;
+    };
+}

--- a/src/LOICollectionA/frontend/ir/Optimizer.cpp
+++ b/src/LOICollectionA/frontend/ir/Optimizer.cpp
@@ -5,6 +5,7 @@
 #include "LOICollectionA/frontend/ir/opt/passes/DeadStorePass.h"
 #include "LOICollectionA/frontend/ir/opt/passes/LICMPass.h"
 #include "LOICollectionA/frontend/ir/opt/passes/CSEPass.h"
+#include "LOICollectionA/frontend/ir/opt/passes/DeadValuePass.h"
 
 #include "LOICollectionA/frontend/ir/Optimizer.h"
 
@@ -74,6 +75,11 @@ namespace LOICollection::frontend::ir {
         opt::CSEPass csePass{ chunk };
         if (this->enabled(Pass::CSE)) {
             ctx.stats.removed += csePass.run();
+        }
+
+        opt::DeadValuePass valuePass{ chunk };
+        if (this->enabled(Pass::DeadCode)) {
+            ctx.stats.removed += valuePass.run();
         }
 
         return ctx.stats;

--- a/src/LOICollectionA/frontend/ir/VM.cpp
+++ b/src/LOICollectionA/frontend/ir/VM.cpp
@@ -335,6 +335,21 @@ namespace LOICollection::frontend::ir {
             ? std::make_shared<GlobalsTable>(*snapshot)
             : std::make_shared<GlobalsTable>());
 
+        struct FrameLimitGuard {
+            std::shared_ptr<sandbox::SandboxBudget> budget;
+            ~FrameLimitGuard() { if (budget) --budget->activeFrames; }
+        } frameGuard;
+
+        if (tlsBudget) {
+            if (tlsBudget->activeFrames >= tlsBudget->maxFrames) {
+                diagnostics.addError({}, "Call stack depth limit exceeded");
+                return ValueNode::ValueType{};
+            }
+
+            ++tlsBudget->activeFrames;
+            frameGuard.budget = tlsBudget;
+        }
+
         vm.frames.clear();
 
         Frame callee(*func->owner->methodBodies[func->bodyIndex]);

--- a/src/LOICollectionA/frontend/ir/opt/passes/CSEPass.cpp
+++ b/src/LOICollectionA/frontend/ir/opt/passes/CSEPass.cpp
@@ -139,7 +139,7 @@ namespace LOICollection::frontend::ir::opt {
                     } else {
                         auto a = regKey.find(ins.src1);
                         if (a != regKey.end())
-                            key = opName(op) + "(" + a->second + ")";
+                            key = opName(op) + "#" + std::to_string(ins.operand) + "(" + a->second + ")";
                     }
 
                     int existing = -1;

--- a/src/LOICollectionA/frontend/ir/opt/passes/ConstantFoldPass.cpp
+++ b/src/LOICollectionA/frontend/ir/opt/passes/ConstantFoldPass.cpp
@@ -52,6 +52,12 @@ namespace LOICollection::frontend::ir::opt {
             return false;
         }
 
+        bool isImmutable(const ValueNode::ValueType& v) {
+            return !std::holds_alternative<ArrayRef>(v)
+                && !std::holds_alternative<ObjectRef>(v)
+                && !std::holds_alternative<FunctionRefPtr>(v);
+        }
+
         bool isZero(const ValueNode::ValueType& v) {
             if (auto i = std::get_if<int>(&v)) return *i == 0;
             if (auto f = std::get_if<float>(&v)) return *f == 0.0f;
@@ -107,7 +113,7 @@ namespace LOICollection::frontend::ir::opt {
         switch (instr.op) {
             case MirOp::LOAD_CONST: {
                 const int at = mCtx.emit(instr);
-                mRegValues[instr.dst] = { mChunk.constants[instr.operand], at, true };
+                mRegValues[instr.dst] = { mChunk.constants[instr.operand], at, isImmutable(mChunk.constants[instr.operand]) };
                 return { at };
             }
 
@@ -292,7 +298,7 @@ namespace LOICollection::frontend::ir::opt {
     }
 
     ConstantFoldPass::Step ConstantFoldPass::foldLoadSlot(const MirInstr& instr) {
-        if (auto it = mSlotValues.find(instr.operand); it != mSlotValues.end()) {
+        if (auto it = mSlotValues.find(instr.operand); it != mSlotValues.end() && it->second.removable) {
             ++mCtx.stats.folded;
             const Step step = emitConst(instr.dst, it->second.value, instr.loc);
             mRegValues[instr.dst] = it->second;
@@ -318,7 +324,7 @@ namespace LOICollection::frontend::ir::opt {
     ConstantFoldPass::Step ConstantFoldPass::foldLoadVar(const MirInstr& instr) {
         const std::string& name = std::get<std::string>(mChunk.constants[instr.operand]);
 
-        if (auto it = mNameValues.find(name); it != mNameValues.end()) {
+        if (auto it = mNameValues.find(name); it != mNameValues.end() && it->second.removable) {
             ++mCtx.stats.folded;
             const Step step = emitConst(instr.dst, it->second.value, instr.loc);
             mRegValues[instr.dst] = it->second;
@@ -582,6 +588,7 @@ namespace LOICollection::frontend::ir::opt {
             return { mCtx.emit({ MirOp::JMP, instr.operand, -1, -1, -1, -1, 0, {}, instr.loc }) };
         }
 
+        ++mCtx.stats.folded;
         ++mCtx.stats.removed;
         return {};
     }
@@ -590,7 +597,7 @@ namespace LOICollection::frontend::ir::opt {
         const int at = emitLoadConst(mChunk, mCtx.foldedCode, value, loc);
         if (dst >= 0)
             mCtx.foldedCode[at].dst = dst;
-        mRegValues[dst] = { value, at, true };
+        mRegValues[dst] = { value, at, isImmutable(value) };
         return { at };
     }
 

--- a/src/LOICollectionA/frontend/ir/opt/passes/DeadValuePass.cpp
+++ b/src/LOICollectionA/frontend/ir/opt/passes/DeadValuePass.cpp
@@ -1,0 +1,80 @@
+#include <unordered_set>
+#include <vector>
+
+#include "LOICollectionA/frontend/ir/opt/analysis/OpTraits.h"
+
+#include "LOICollectionA/frontend/ir/opt/passes/DeadValuePass.h"
+
+namespace LOICollection::frontend::ir::opt {
+    size_t DeadValuePass::run() {
+        if (mChunk.code.empty())
+            return 0;
+
+        std::unordered_set<int> read;
+        std::unordered_set<int> pinned;
+
+        for (const MirInstr& instr : mChunk.code) {
+            if (instr.src1 >= 0)
+                read.insert(instr.src1);
+            if (instr.src2 >= 0)
+                read.insert(instr.src2);
+            if (instr.src3 >= 0)
+                read.insert(instr.src3);
+
+            if (instr.imm > 0 && instr.src1 >= 0) {
+                for (int i = 0; i < instr.imm; ++i)
+                    read.insert(instr.src1 + i);
+            }
+
+            if (instr.op == MirOp::STORE_SLOT || instr.op == MirOp::LOAD_SLOT)
+                pinned.insert(instr.operand);
+
+            if (instr.op == MirOp::HALT)
+                pinned.insert(0);
+        }
+
+        std::vector<MirInstr> out;
+        out.reserve(mChunk.code.size());
+        std::vector<int> oldToNew(mChunk.code.size(), -1);
+        std::vector<int> origin;
+        size_t eliminated = 0;
+
+        for (size_t i = 0; i < mChunk.code.size(); ++i) {
+            const MirInstr& instr = mChunk.code[i];
+
+            if (instr.op == MirOp::LOAD_CONST && instr.dst >= 0 &&
+                read.find(instr.dst) == read.end() &&
+                pinned.find(instr.dst) == pinned.end()) {
+                ++eliminated;
+                continue;
+            }
+
+            out.push_back(instr);
+            oldToNew[i] = static_cast<int>(out.size()) - 1;
+            origin.push_back(static_cast<int>(i));
+        }
+
+        if (eliminated == 0)
+            return 0;
+
+        for (size_t k = 0; k < out.size(); ++k) {
+            if (!isJump(out[k].op))
+                continue;
+
+            const int oldTarget = origin[k] + 1 + out[k].operand;
+
+            int newTarget = oldToNew[oldTarget];
+            for (int j = oldTarget; j < static_cast<int>(oldToNew.size()) && newTarget < 0; ++j)
+                newTarget = oldToNew[j];
+
+            if (newTarget < 0)
+                newTarget = static_cast<int>(out.size());
+
+            out[k].operand = newTarget - static_cast<int>(k) - 1;
+        }
+
+        mChunk.code = std::move(out);
+
+        return eliminated;
+    }
+}

--- a/src/LOICollectionA/frontend/ir/opt/passes/DeadValuePass.h
+++ b/src/LOICollectionA/frontend/ir/opt/passes/DeadValuePass.h
@@ -1,0 +1,16 @@
+#pragma once
+
+#include "LOICollectionA/frontend/ir/Mir.h"
+
+namespace LOICollection::frontend::ir::opt {
+    class DeadValuePass {
+    public:
+        explicit DeadValuePass(MirChunk& chunk)
+        : mChunk(chunk) {}
+
+        size_t run();
+
+    private:
+        MirChunk& mChunk;
+    };
+}

--- a/src/LOICollectionA/frontend/ir/vm/VMExecArith.cpp
+++ b/src/LOICollectionA/frontend/ir/vm/VMExecArith.cpp
@@ -336,7 +336,13 @@ namespace LOICollection::frontend::ir {
         const auto* li = std::get_if<int>(&lv);
         const auto* ri = std::get_if<int>(&rv);
 
-        if (li && ri) {
+        const bool integralFastPath =
+            instr.op == MirOp::ADD ||
+            instr.op == MirOp::SUB ||
+            instr.op == MirOp::MUL ||
+            instr.op == MirOp::MOD;
+
+        if (li && ri && integralFastPath) {
             const int l = *li;
             const int r = *ri;
 

--- a/src/LOICollectionA/frontend/parser/ParserDecl.cpp
+++ b/src/LOICollectionA/frontend/parser/ParserDecl.cpp
@@ -44,6 +44,13 @@ namespace LOICollection::frontend {
     }
 
     std::unique_ptr<TypeExpr> Parser::parseTypeExpr() {
+        DepthGuard guard(parseDepth);
+
+        if (parseDepth > kMaxParseDepth) {
+            diagnostics.addError(currentToken.loc, "Type nesting exceeds the maximum supported depth");
+            return nullptr;
+        }
+
         if (currentToken.type != TokenType::TOKEN_IDENT) {
             diagnostics.addError(currentToken.loc, "Expected type name");
             return nullptr;

--- a/src/LOICollectionA/frontend/parser/ParserExpr.cpp
+++ b/src/LOICollectionA/frontend/parser/ParserExpr.cpp
@@ -251,6 +251,13 @@ namespace LOICollection::frontend {
     }
 
     std::unique_ptr<ExprNode> Parser::parsePowerExpression() {
+        DepthGuard guard(parseDepth);
+
+        if (parseDepth > kMaxParseDepth) {
+            diagnostics.addError(currentToken.loc, "Expression nesting exceeds the maximum supported depth");
+            return nullptr;
+        }
+
         auto left = parseUnaryExpression();
         if (!left)
             return nullptr;
@@ -272,6 +279,13 @@ namespace LOICollection::frontend {
     }
 
     std::unique_ptr<ExprNode> Parser::parseUnaryExpression() {
+        DepthGuard guard(parseDepth);
+
+        if (parseDepth > kMaxParseDepth) {
+            diagnostics.addError(currentToken.loc, "Expression nesting exceeds the maximum supported depth");
+            return nullptr;
+        }
+
         if (currentToken.type == TokenType::TOKEN_INCREMENT || currentToken.type == TokenType::TOKEN_DECREMENT) {
             SourceLocation loc = currentToken.loc;
             std::string op = currentToken.type == TokenType::TOKEN_INCREMENT ? "+" : "-";
@@ -434,6 +448,13 @@ namespace LOICollection::frontend {
     }
 
     std::unique_ptr<ExprNode> Parser::parsePrimary() {
+        DepthGuard guard(parseDepth);
+
+        if (parseDepth > kMaxParseDepth) {
+            diagnostics.addError(currentToken.loc, "Expression nesting exceeds the maximum supported depth");
+            return nullptr;
+        }
+
         switch (currentToken.type) {
             case TokenType::TOKEN_IF:
                 return parseIfStatement();
@@ -603,7 +624,7 @@ namespace LOICollection::frontend {
                 return std::make_unique<ValueNode>(loc, std::monostate{});
             default:
                 diagnostics.addError(currentToken.loc, "Unexpected value type: " + currentToken.value);
-                return std::make_unique<ValueNode>(loc, 0);
+                return nullptr;
         }
     }
 

--- a/src/LOICollectionA/frontend/parser/ParserStmt.cpp
+++ b/src/LOICollectionA/frontend/parser/ParserStmt.cpp
@@ -337,6 +337,9 @@ namespace LOICollection::frontend {
 
         int bracketDepth = 0;
         while (currentToken.type != TokenType::TOKEN_EOF) {
+            if (currentToken.type == TokenType::TOKEN_RBRACE)
+                break;
+
             if (currentToken.type == TokenType::TOKEN_LBRCKET) {
                 bracketDepth++;
             } else if (currentToken.type == TokenType::TOKEN_RBRCKET && bracketDepth > 0) {
@@ -344,9 +347,6 @@ namespace LOICollection::frontend {
             }
 
             if (bracketDepth == 0) {
-                if (currentToken.type == TokenType::TOKEN_RBRACE)
-                    break;
-
                 if (currentToken.type == TokenType::TOKEN_RBRCKET &&
                     stopToken != TokenType::TOKEN_RBRCKET)
                     break;
@@ -496,6 +496,13 @@ namespace LOICollection::frontend {
     }
 
     std::unique_ptr<ASTNode> Parser::parseStatement() {
+        DepthGuard guard(parseDepth);
+
+        if (parseDepth > kMaxParseDepth) {
+            diagnostics.addError(currentToken.loc, "Statement nesting exceeds the maximum supported depth");
+            return nullptr;
+        }
+
         if (currentToken.type == TokenType::TOKEN_FUNC && peek() != TokenType::TOKEN_LPAREN)
             return parseFunctionDefinition();
 

--- a/src/LOICollectionA/frontend/sandbox/SandboxBudget.h
+++ b/src/LOICollectionA/frontend/sandbox/SandboxBudget.h
@@ -19,6 +19,7 @@ namespace LOICollection::frontend::sandbox {
         std::size_t nativeCallCount = 0;
         std::size_t objectCount = 0;
         std::size_t allocatedBytes = 0;
+        std::size_t activeFrames = 0;
 
         void reset() {
             startTime = std::chrono::steady_clock::now();
@@ -26,6 +27,7 @@ namespace LOICollection::frontend::sandbox {
             nativeCallCount = 0;
             objectCount = 0;
             allocatedBytes = 0;
+            activeFrames = 0;
         }
 
         enum class Violation {
@@ -37,6 +39,7 @@ namespace LOICollection::frontend::sandbox {
             ArrayElementLimit,
             StringByteLimit,
             TotalByteLimit,
+            FrameLimit,
         };
 
         Violation tickInstruction() {

--- a/src/LOICollectionA/include/form/GUIManager.h
+++ b/src/LOICollectionA/include/form/GUIManager.h
@@ -98,6 +98,7 @@ namespace LOICollection::form {
         GUIManager();
 
         ll::Expected<std::string> readFile(const std::string& path);
+        ll::Expected<void> writeFile(const std::string& path, const std::string& content);
 
         struct Impl;
         std::unique_ptr<Impl> mImpl;

--- a/src/LOICollectionA/modules/form/GUIManager.cpp
+++ b/src/LOICollectionA/modules/form/GUIManager.cpp
@@ -169,7 +169,7 @@ namespace LOICollection::form {
             hasSource = true;
         }
 
-        const std::string packagePath = path + ".lcub";
+        const std::string packagePath = path + ".lcp";
 
         if (auto blob = this->readFile(packagePath); blob.has_value()) {
             std::string bodyChecksum;

--- a/src/LOICollectionA/modules/form/GUIManager.cpp
+++ b/src/LOICollectionA/modules/form/GUIManager.cpp
@@ -24,6 +24,7 @@
 #include "LOICollectionA/frontend/ir/VM.h"
 #include "LOICollectionA/frontend/ir/Compiler.h"
 #include "LOICollectionA/frontend/ir/Optimizer.h"
+#include "LOICollectionA/frontend/ir/MirSerializer.h"
 #include "LOICollectionA/frontend/ir/Abi.h"
 
 #include "LOICollectionA/utils/core/Sha256.h"
@@ -110,47 +111,98 @@ namespace LOICollection::form {
         return content;
     }
 
+    ll::Expected<void> GUIManager::writeFile(const std::string& path, const std::string& content) {
+        std::ofstream file(path, std::ios::binary);
+        if (!file)
+            return ll::makeErrorCodeError(std::make_error_code(std::errc::io_error));
+
+        if (!file.write(content.data(), static_cast<std::streamsize>(content.size())))
+            return ll::makeErrorCodeError(std::make_error_code(std::errc::io_error));
+
+        return {};
+    }
+
     ll::Expected<void> GUIManager::load(const std::string& id, const std::string& path) {
         frontend::DiagnosticEngine diagnostics;
 
-        const bool hasSource = this->readFile(path).has_value();
+        using Serializer = frontend::ir::MirSerializer;
+
+        Serializer::Header header;
+        header.scriptId = id;
+        header.abiFingerprint = frontend::ir::abiFingerprint();
+
+        std::shared_ptr<frontend::ir::MirChunk> compiled;
+        bool hasSource = false;
+
+        if (auto content = this->readFile(path); content.has_value()) {
+            const std::string rootDir = std::filesystem::path(path).parent_path().string();
+            auto result = frontend::ScriptLoader::load(
+                path, rootDir,
+                [this](const std::string& file) -> std::optional<std::string> {
+                    auto data = this->readFile(file);
+                    if (!data.has_value())
+                        return std::nullopt;
+
+                    return data.value();
+                },
+                diagnostics
+            );
+            if (!result)
+                return ll::makeStringError(diagnostics.getErrorMessage());
+
+            frontend::SemanticAnalyzer analyzer(diagnostics);
+            analyzer.analyze(*result->program);
+
+            if (diagnostics.hasErrors())
+                return ll::makeStringError(diagnostics.getErrorMessage());
+
+            if (diagnostics.hasWarnings())
+                return ll::makeStringError(diagnostics.getWarningMessage());
+
+            frontend::ir::Compiler mCompiler(diagnostics);
+            compiled = std::make_shared<frontend::ir::MirChunk>(mCompiler.compile(*result->program));
+            if (diagnostics.hasErrors())
+                return ll::makeStringError(diagnostics.getErrorMessage());
+
+            header.sourceHash = result->hashes.back();
+            header.importHashes.assign(result->hashes.begin(), result->hashes.end() - 1);
+            hasSource = true;
+        }
+
+        const std::string packagePath = path + ".lcub";
+
+        if (auto blob = this->readFile(packagePath); blob.has_value()) {
+            std::string bodyChecksum;
+
+            if (auto chunk = Serializer::deserialize(blob.value(), header, &bodyChecksum)) {
+                if (auto debug = this->readFile(packagePath + ".dbg"); debug.has_value())
+                    Serializer::attachDebugInfo(*chunk, debug.value(), bodyChecksum);
+
+                this->mImpl->cache.insert_or_assign(id, std::make_shared<frontend::ir::MirChunk>(std::move(*chunk)));
+                warnIfMissingPermission(id);
+                return {};
+            }
+        }
+
         if (!hasSource)
-            return ll::makeStringError("load: Script '" + id + "' has no readable source");
-
-        const std::string rootDir = std::filesystem::path(path).parent_path().string();
-        auto result = frontend::ScriptLoader::load(
-            path, rootDir,
-            [this](const std::string& file) -> std::optional<std::string> {
-                auto data = this->readFile(file);
-                if (!data.has_value())
-                    return std::nullopt;
-
-                return data.value();
-            },
-            diagnostics
-        );
-        if (!result)
-            return ll::makeStringError(diagnostics.getErrorMessage());
-
-        frontend::ir::Compiler mCompiler(diagnostics);
-
-        frontend::SemanticAnalyzer analyzer(diagnostics);
-        analyzer.analyze(*result->program);
-
-        if (diagnostics.hasErrors())
-            return ll::makeStringError(diagnostics.getErrorMessage());
-
-        if (diagnostics.hasWarnings())
-            return ll::makeStringError(diagnostics.getWarningMessage());
-
-        auto mir = std::make_shared<frontend::ir::MirChunk>(mCompiler.compile(*result->program));
-        if (diagnostics.hasErrors())
-            return ll::makeStringError(diagnostics.getErrorMessage());
+            return ll::makeStringError(
+                "load: Script '" + id + "' has no readable source and no valid bytecode package");
 
         frontend::ir::Optimizer optimizer;
-        optimizer.optimize(*mir);
+        optimizer.optimize(*compiled);
 
-        this->mImpl->cache.insert_or_assign(id, mir);
+        if (diagnostics.hasErrors())
+            return ll::makeStringError(diagnostics.getErrorMessage());
+
+        std::string bodyChecksum;
+        auto blob = Serializer::serialize(*compiled, header, &bodyChecksum);
+        if (blob) {
+            this->writeFile(packagePath, *blob);
+            if (auto debug = Serializer::serializeDebugInfo(*compiled, bodyChecksum))
+                this->writeFile(packagePath + ".dbg", *debug);
+        }
+
+        this->mImpl->cache.insert_or_assign(id, compiled);
         warnIfMissingPermission(id);
 
         return {};

--- a/tests/common/frontend/LexerTest.cpp
+++ b/tests/common/frontend/LexerTest.cpp
@@ -285,3 +285,26 @@ TEST(LexerTest, PeekDoesNotAdvance) {
     auto real2 = lexer.getNextToken();
     EXPECT_EQ(real2.type, TokenType::TOKEN_INT);
 }
+
+TEST(LexerTest, UnexpectedCharactersAlwaysAdvance) {
+    for (const std::string src : {
+            std::string("`"),
+            std::string("@"),
+            std::string("#"),
+            std::string("~"),
+            std::string("\x80\x81\xff"),
+            std::string("let a = `;"),
+            std::string("func f() { ` }"),
+            std::string("class C { ` }"),
+         }) {
+        DiagnosticEngine diagnostics;
+        Lexer lexer(src, diagnostics);
+
+        int count = 0;
+        while (lexer.getNextToken().type != TokenType::TOKEN_EOF && count < 1000000)
+            ++count;
+
+        EXPECT_LT(count, 1000000) << "lexer did not terminate on input: " << src;
+        EXPECT_TRUE(diagnostics.hasErrors());
+    }
+}

--- a/tests/common/frontend/MirSerializerTest.cpp
+++ b/tests/common/frontend/MirSerializerTest.cpp
@@ -81,6 +81,43 @@ namespace {
 
         return header;
     }
+
+    std::unique_ptr<MirChunk> nestedChunk(int depth) {
+        auto root = std::make_unique<MirChunk>();
+        root->slotCount = 0;
+
+        MirChunk* tail = root.get();
+        for (int i = 0; i < depth; ++i) {
+            tail->methodBodies.push_back(std::make_unique<MirChunk>());
+            tail = tail->methodBodies.back().get();
+        }
+
+        return root;
+    }
+
+    int nestingDepth(const MirChunk& chunk) {
+        int depth = 0;
+
+        const MirChunk* cursor = &chunk;
+        while (!cursor->methodBodies.empty()) {
+            cursor = cursor->methodBodies.front().get();
+            ++depth;
+        }
+
+        return depth;
+    }
+
+    ValueNode::ValueType nestedArray(int depth) {
+        ValueNode::ValueType value = std::make_shared<ArrayValue>();
+
+        for (int i = 0; i < depth; ++i) {
+            auto outer = std::make_shared<ArrayValue>();
+            outer->elements.push_back(value);
+            value = std::move(outer);
+        }
+
+        return value;
+    }
 }
 
 TEST(MirSerializerTest, RoundTripPreservesBehavior) {
@@ -229,4 +266,45 @@ TEST(MirSerializerTest, DebugInfoRejectsMismatchedChecksum) {
 
     const std::string wrongChecksum(32, 'B');
     EXPECT_FALSE(MirSerializer::attachDebugInfo(*restored, debugBlob.value(), wrongChecksum));
+}
+
+TEST(MirSerializerTest, AcceptsNestedMethodBodies) {
+    auto chunk = nestedChunk(8);
+
+    auto blob = MirSerializer::serialize(*chunk, headerFor(kSource));
+    ASSERT_TRUE(blob.has_value());
+
+    auto restored = MirSerializer::deserialize(blob.value(), headerFor(kSource));
+    ASSERT_TRUE(restored.has_value());
+
+    EXPECT_EQ(nestingDepth(*restored), 8);
+}
+
+TEST(MirSerializerTest, RejectsExcessiveNesting) {
+    auto chunk = nestedChunk(4096);
+
+    auto blob = MirSerializer::serialize(*chunk, headerFor(kSource));
+    ASSERT_TRUE(blob.has_value());
+
+    EXPECT_FALSE(MirSerializer::deserialize(blob.value(), headerFor(kSource)).has_value());
+}
+
+TEST(MirSerializerTest, RejectsExcessiveConstantNesting) {
+    MirChunk chunk;
+    chunk.slotCount = 0;
+    chunk.constants.push_back(nestedArray(4096));
+
+    auto blob = MirSerializer::serialize(chunk, headerFor(kSource));
+    ASSERT_TRUE(blob.has_value());
+
+    EXPECT_FALSE(MirSerializer::deserialize(blob.value(), headerFor(kSource)).has_value());
+
+    MirChunk usable;
+    usable.slotCount = 0;
+    usable.constants.push_back(nestedArray(8));
+
+    auto usableBlob = MirSerializer::serialize(usable, headerFor(kSource));
+    ASSERT_TRUE(usableBlob.has_value());
+
+    EXPECT_TRUE(MirSerializer::deserialize(usableBlob.value(), headerFor(kSource)).has_value());
 }

--- a/tests/common/frontend/MirSerializerTest.cpp
+++ b/tests/common/frontend/MirSerializerTest.cpp
@@ -1,0 +1,232 @@
+#include <gtest/gtest.h>
+
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "LOICollectionA/frontend/DiagnosticEngine.h"
+#include "LOICollectionA/frontend/Lexer.h"
+#include "LOICollectionA/frontend/Parser.h"
+#include "LOICollectionA/frontend/SemanticAnalyzer.h"
+
+#include "LOICollectionA/frontend/ir/Compiler.h"
+#include "LOICollectionA/frontend/ir/Mir.h"
+#include "LOICollectionA/frontend/ir/MirSerializer.h"
+#include "LOICollectionA/frontend/ir/Optimizer.h"
+#include "LOICollectionA/frontend/ir/VM.h"
+
+#include "LOICollectionA/utils/core/Sha256.h"
+
+using namespace LOICollection::frontend;
+using namespace LOICollection::frontend::ir;
+using LOICollection::utils::Sha256;
+
+namespace {
+    std::shared_ptr<MirChunk> compileScript(const std::string& source) {
+        DiagnosticEngine diagnostics;
+
+        Lexer lexer(source, diagnostics);
+        Parser parser(lexer, diagnostics);
+
+        auto ast = parser.parse();
+        if (diagnostics.hasErrors())
+            return nullptr;
+
+        SemanticAnalyzer analyzer(diagnostics);
+        analyzer.analyze(static_cast<ProgramNode&>(*ast));
+        if (diagnostics.hasErrors())
+            return nullptr;
+
+        auto chunk = std::make_shared<MirChunk>(Compiler(diagnostics).compile(*ast));
+        if (diagnostics.hasErrors())
+            return nullptr;
+
+        Optimizer optimizer;
+        optimizer.optimize(*chunk);
+
+        return chunk;
+    }
+
+    std::string runChunk(const std::shared_ptr<MirChunk>& chunk) {
+        DiagnosticEngine diagnostics;
+
+        ir::VM vm(diagnostics);
+        auto result = vm.run(chunk, {});
+        if (diagnostics.hasErrors())
+            return {};
+
+        return ir::VM::valueToString(result);
+    }
+
+    const std::string kSource = R"(
+        let twice = func (n: int) -> int {
+            return n * 2;
+        };
+
+        let result = twice(21);
+        result
+    )";
+
+    MirSerializer::Header headerFor(
+        const std::string& source,
+        const std::vector<std::string>& imports = {}
+    ) {
+        MirSerializer::Header header;
+        header.scriptId = "test";
+        header.abiFingerprint = std::string(32, 'A');
+        header.sourceHash = Sha256::compute(source);
+
+        for (const auto& import : imports)
+            header.importHashes.push_back(Sha256::compute(import));
+
+        return header;
+    }
+}
+
+TEST(MirSerializerTest, RoundTripPreservesBehavior) {
+    auto chunk = compileScript(kSource);
+    ASSERT_NE(chunk, nullptr);
+
+    auto blob = MirSerializer::serialize(*chunk, headerFor(kSource));
+    ASSERT_TRUE(blob.has_value());
+
+    auto restored = MirSerializer::deserialize(blob.value(), headerFor(kSource));
+    ASSERT_TRUE(restored.has_value());
+
+    EXPECT_EQ(runChunk(std::make_shared<MirChunk>(std::move(*restored))), "42");
+}
+
+TEST(MirSerializerTest, RoundTripIsStableAcrossCycles) {
+    auto chunk = compileScript(kSource);
+    ASSERT_NE(chunk, nullptr);
+
+    auto first = MirSerializer::serialize(*chunk, headerFor(kSource));
+    ASSERT_TRUE(first.has_value());
+
+    auto restored = MirSerializer::deserialize(first.value(), headerFor(kSource));
+    ASSERT_TRUE(restored.has_value());
+
+    auto second = MirSerializer::serialize(*restored, headerFor(kSource));
+    ASSERT_TRUE(second.has_value());
+
+    EXPECT_EQ(first.value(), second.value());
+}
+
+TEST(MirSerializerTest, RoundTripWithImportHashes) {
+    auto chunk = compileScript(kSource);
+    ASSERT_NE(chunk, nullptr);
+
+    const std::string libSource = "func base() -> int {\n    return 1;\n}";
+    auto header = headerFor(kSource, { libSource });
+
+    auto blob = MirSerializer::serialize(*chunk, header);
+    ASSERT_TRUE(blob.has_value());
+
+    auto restored = MirSerializer::deserialize(blob.value(), header);
+    ASSERT_TRUE(restored.has_value());
+}
+
+TEST(MirSerializerTest, PeekHeaderRecoversMetadata) {
+    auto chunk = compileScript(kSource);
+    ASSERT_NE(chunk, nullptr);
+
+    auto header = headerFor(kSource);
+    auto blob = MirSerializer::serialize(*chunk, header);
+    ASSERT_TRUE(blob.has_value());
+
+    auto peeked = MirSerializer::peekHeader(blob.value());
+    ASSERT_TRUE(peeked.has_value());
+
+    EXPECT_EQ(peeked->scriptId, header.scriptId);
+    EXPECT_EQ(peeked->abiFingerprint, header.abiFingerprint);
+    EXPECT_EQ(peeked->sourceHash, header.sourceHash);
+}
+
+TEST(MirSerializerTest, RejectsChangedSourceHash) {
+    auto chunk = compileScript(kSource);
+    ASSERT_NE(chunk, nullptr);
+
+    auto blob = MirSerializer::serialize(*chunk, headerFor(kSource));
+    ASSERT_TRUE(blob.has_value());
+
+    auto stale = headerFor(kSource + "\n");
+    EXPECT_FALSE(MirSerializer::deserialize(blob.value(), stale).has_value());
+}
+
+TEST(MirSerializerTest, RejectsChangedImportHash) {
+    auto chunk = compileScript(kSource);
+    ASSERT_NE(chunk, nullptr);
+
+    const std::string libSource = "func base() -> int {\n    return 1;\n}";
+    auto blob = MirSerializer::serialize(*chunk, headerFor(kSource, { libSource }));
+    ASSERT_TRUE(blob.has_value());
+
+    auto stale = headerFor(kSource, { libSource + "\n" });
+    EXPECT_FALSE(MirSerializer::deserialize(blob.value(), stale).has_value());
+}
+
+TEST(MirSerializerTest, RejectsImportCountMismatch) {
+    auto chunk = compileScript(kSource);
+    ASSERT_NE(chunk, nullptr);
+
+    const std::string libSource = "func base() -> int {\n    return 1;\n}";
+    auto blob = MirSerializer::serialize(*chunk, headerFor(kSource, { libSource }));
+    ASSERT_TRUE(blob.has_value());
+
+    auto stale = headerFor(kSource, { libSource, libSource });
+    EXPECT_FALSE(MirSerializer::deserialize(blob.value(), stale).has_value());
+}
+
+TEST(MirSerializerTest, RejectsCorruptedBlob) {
+    auto chunk = compileScript(kSource);
+    ASSERT_NE(chunk, nullptr);
+
+    auto blob = MirSerializer::serialize(*chunk, headerFor(kSource));
+    ASSERT_TRUE(blob.has_value());
+
+    const auto& header = headerFor(kSource);
+
+    EXPECT_FALSE(MirSerializer::deserialize("not a cache blob", header).has_value());
+
+    auto truncated = blob.value().substr(0, blob.value().size() - 1);
+    EXPECT_FALSE(MirSerializer::deserialize(truncated, header).has_value());
+
+    auto damaged = blob.value();
+    damaged[damaged.size() / 2] = static_cast<char>(damaged[damaged.size() / 2] ^ 0x40);
+    EXPECT_FALSE(MirSerializer::deserialize(damaged, header).has_value());
+}
+
+TEST(MirSerializerTest, DebugInfoRoundTrip) {
+    auto chunk = compileScript(kSource);
+    ASSERT_NE(chunk, nullptr);
+
+    std::string bodyChecksum;
+    auto blob = MirSerializer::serialize(*chunk, headerFor(kSource), &bodyChecksum);
+    ASSERT_TRUE(blob.has_value());
+
+    auto debugBlob = MirSerializer::serializeDebugInfo(*chunk, bodyChecksum);
+    ASSERT_TRUE(debugBlob.has_value());
+
+    auto restored = MirSerializer::deserialize(blob.value(), headerFor(kSource));
+    ASSERT_TRUE(restored.has_value());
+
+    EXPECT_TRUE(MirSerializer::attachDebugInfo(*restored, debugBlob.value(), bodyChecksum));
+}
+
+TEST(MirSerializerTest, DebugInfoRejectsMismatchedChecksum) {
+    auto chunk = compileScript(kSource);
+    ASSERT_NE(chunk, nullptr);
+
+    std::string bodyChecksum;
+    auto blob = MirSerializer::serialize(*chunk, headerFor(kSource), &bodyChecksum);
+    ASSERT_TRUE(blob.has_value());
+
+    auto debugBlob = MirSerializer::serializeDebugInfo(*chunk, bodyChecksum);
+    ASSERT_TRUE(debugBlob.has_value());
+
+    auto restored = MirSerializer::deserialize(blob.value(), headerFor(kSource));
+    ASSERT_TRUE(restored.has_value());
+
+    const std::string wrongChecksum(32, 'B');
+    EXPECT_FALSE(MirSerializer::attachDebugInfo(*restored, debugBlob.value(), wrongChecksum));
+}

--- a/tests/common/frontend/OptimizerTest.cpp
+++ b/tests/common/frontend/OptimizerTest.cpp
@@ -747,16 +747,16 @@ TEST(OptimizerTest, RemovesStoreOverwrittenBeforeAnyRead) {
 
 TEST(OptimizerTest, RemovesDeadSlotStoreInStraightLineCode) {
     ir::MirChunk chunk;
-    chunk.slotCount = 1;
+    chunk.slotCount = 4;
     chunk.constants.push_back(1);
     chunk.constants.push_back(2);
 
     chunk.code = {
-        { MirOp::LOAD_CONST, 0, 0 },
-        { MirOp::STORE_SLOT, 0, -1, 0 },
-        { MirOp::LOAD_CONST, 1, 1 },
+        { MirOp::LOAD_CONST, 0, 1 },
         { MirOp::STORE_SLOT, 0, -1, 1 },
-        { MirOp::LOAD_SLOT, 0, 2, 0 },
+        { MirOp::LOAD_CONST, 1, 2 },
+        { MirOp::STORE_SLOT, 0, -1, 2 },
+        { MirOp::LOAD_SLOT, 0, 3, -1 },
         { MirOp::HALT, 0 }
     };
 

--- a/tests/common/frontend/ParserTest.cpp
+++ b/tests/common/frontend/ParserTest.cpp
@@ -204,3 +204,37 @@ TEST(ParserEvalTest, TranspileEdgeCases) {
     EXPECT_EQ(eval("$a;"), "a;");
     EXPECT_EQ(eval("1 + $x}"), "1x}");
 }
+
+TEST(ParserEvalTest, UnterminatedArrayInBlockReportsError) {
+    EXPECT_THROW(eval("func f() -> int {\n    let a = 1;\n[\n}\nf();\n"), std::runtime_error);
+    EXPECT_THROW(eval("func f() -> int {\n    let a = 1;\n[\n    let b = 2;\n}\nf();\n"), std::runtime_error);
+}
+
+TEST(ParserEvalTest, UnbalancedBracketDoesNotSwallowBlockEnd) {
+    EXPECT_THROW(eval("func f() -> int {\n    let a = arr[0;\n    return a;\n}\nf();\n"), std::runtime_error);
+    EXPECT_THROW(eval("func f() -> int {\n    let a = 1;\n]\n}\nf();\n"), std::runtime_error);
+}
+
+TEST(ParserEvalTest, ExcessiveExpressionNestingIsRejected) {
+    EXPECT_THROW(eval(std::string(2048, '(') + "1" + std::string(2048, ')')), std::runtime_error);
+    EXPECT_THROW(eval(std::string(2048, '[') + "1" + std::string(2048, ']')), std::runtime_error);
+    EXPECT_THROW(eval(std::string(1024, '!') + "true"), std::runtime_error);
+    EXPECT_THROW(eval("2" + std::string(1024, '^') + "2;"), std::runtime_error);
+}
+
+TEST(ParserEvalTest, ExcessiveTypeNestingIsRejected) {
+    std::string nested;
+    for (int i = 0; i < 1024; ++i)
+        nested += "a<";
+
+    nested += "int";
+    for (int i = 0; i < 1024; ++i)
+        nested += '>';
+
+    EXPECT_THROW(eval("using X = " + nested + ";"), std::runtime_error);
+}
+
+TEST(ParserEvalTest, NestingWithinBudgetIsAccepted) {
+    EXPECT_EQ(eval(std::string(64, '(') + "1" + std::string(64, ')')), "1");
+    EXPECT_EQ(eval(std::string(64, '!') + "true"), "true");
+}

--- a/tests/common/frontend/ScriptLoaderTest.cpp
+++ b/tests/common/frontend/ScriptLoaderTest.cpp
@@ -134,6 +134,34 @@ TEST(ScriptLoaderTest, RejectsConflictingDefinitions) {
     EXPECT_NE(diagnostics.getErrorMessage().find("conflicts with"), std::string::npos);
 }
 
+TEST(ScriptLoaderTest, AllowsOverloadedFunctions) {
+    FileMap files = {
+        {"/main.lcui",
+         "func id(x: int) -> int {\n    return x;\n}\n"
+         "func id(x: string) -> string {\n    return x;\n}"},
+    };
+
+    DiagnosticEngine diagnostics;
+    auto loaded = ScriptLoader::load("/main.lcui", "/", readerFor(files), diagnostics);
+
+    ASSERT_TRUE(loaded.has_value());
+    EXPECT_FALSE(diagnostics.hasErrors());
+}
+
+TEST(ScriptLoaderTest, RejectsDuplicateFunctionSignatures) {
+    FileMap files = {
+        {"/main.lcui", "import \"a.lcui\";\nimport \"b.lcui\";"},
+        {"/a.lcui", "func dup(x: int) -> int {\n    return 1;\n}"},
+        {"/b.lcui", "func dup(x: int) -> int {\n    return 2;\n}"},
+    };
+
+    DiagnosticEngine diagnostics;
+    auto loaded = ScriptLoader::load("/main.lcui", "/", readerFor(files), diagnostics);
+
+    EXPECT_FALSE(loaded.has_value());
+    EXPECT_NE(diagnostics.getErrorMessage().find("conflicts with"), std::string::npos);
+}
+
 TEST(ScriptLoaderTest, MissingImportFileReportsError) {
     FileMap files = {
         {"/main.lcui", "import \"gone.lcui\";"},


### PR DESCRIPTION
## Overview

Based on `refactor/frontend-mir` (starting from `20b2847`, the MIR serialization commit), 18 commits total.

The first 10 commits are pipeline cleanup and serialization restoration; this PR's fix layer consists of the last 8:

| Commit | Type | Description |
|--------|------|-------------|
| `115a774` | fix | Preserve aliasing semantics for mutable values (array/object/function references) during constant folding; unknown values are no longer treated as removable constant propagation |
| `c7b4ae6` | fix | `emitLoad` for slot variables emits `LOAD_SLOT` into a new register instead of returning the slot number as a register number |
| `c3d65b4` | fix | Implicit return of function bodies/lambdas no longer leaks the initial value of `let` declarations |
| `0809771` | fix | VM arithmetic int/int fast path only covers ADD/SUB/MUL/MOD; DIV/POW fall back to the generic path (no longer silently return 0) |
| `841bb8c` | fix | CSE unary operation key includes `operand`, fixing `a instanceof A` and `a instanceof B` being incorrectly reused |
| `28383d3` | feat | Add `DeadValuePass` to delete `LOAD_CONST` instructions no longer read after folding/CSE (dead value elimination) |
| `9352af4` | test | Fix MIR construction in `RemovesDeadSlotStoreInStraightLineCode` (slotCount and register number conflict) |
| `20b2847` | feat | Restore `MirSerializer`: recover bytecode caching/persistence capability after MIR direct execution |

## Rationale for removing the `_I` specializations

The `_I` opcode family was introduced in the stack-based bytecode VM era (`ca20424`) to avoid `std::variant` visits. After the MIR direct-execution refactor (`8e0c6e1`):

- The VM fast path uses `std::get_if<int>` to check operand types and **no longer reads the opcode**; `ADD` and `ADD_I` fall into the same branch, making the specialization dead weight.
- All consumers still had to list both spellings in `switch` statements; `VMExecArith::genericOp` and the test-side `intVariant` existed only to collapse the two spellings back into one.
- `ConstantFoldPass` even had a `NEG_I` branch whose body was **byte-for-byte identical** to the `NEG` branch, showing the specialization had already rotted.

After removal, `emitBinary` is simplified from a `(generic, int)` pair to a single op. Behavior is unchanged: the VM fast path and optimizer predicates already used the generic opcode, and the compiler now emits it directly.

## Constant folding fixes (`a63dca5`)

While validating optimization correctness, three defects in the MIR constant-folding pass were found and fixed:

1. **`emitConst` dropped the destination register**: the generated `LOAD_CONST` hardcoded `dst=-1`, so folded results were never written to the target register. It now takes `instr.dst` explicitly and writes the result back to `mRegValues`.

2. **`foldBinary` misapplied identity folding**: left-operand identity folding still read an uninitialized `Known::value` when `lk=false` (`std::variant` default-constructs to `int(0)`), incorrectly folding `n-1` into the constant `1` and causing recursive `fib` to never terminate (stack depth exceeded). Fixed by requiring both operands to be known and restricting left-operand identity folding to commutative `ADD`/`MUL`.

3. **Unity build symbol redefinition**: `CSEPass` and `LICMPass` each defined `isPureBinary`/`isPureUnary` in anonymous namespaces; xmake's `c++.unity_build` merges multiple TUs, causing redefinition. These are now extracted as `inline` helpers in `OpTraits.h`.

Also removed the unused `oldIdx` parameter and a dead variable `owner` to eliminate compiler warnings.

## Bug details fixed in this round

1. **Constant propagation of array/object/function references breaks aliasing** (`115a774`): `ArrayRef`/`ObjectRef`/`FunctionRefPtr` are mutable references, and `LOAD_CONST` would deep-copy arrays. The original `emitConst` and `LOAD_CONST` folding branch marked known array values as removable, so `foldLoadVar`/`foldLoadSlot` replaced the original slot with a clone, causing `a[1]=2` to modify the clone instead of `a`. Added an `isImmutable` check; `emitConst`/`LOAD_CONST` set `removable` based on value type, and `foldLoadVar`/`foldLoadSlot` only propagate after checking `removable`.

2. **`emitLoad` for slot variables directly returns the slot number** (`c7b4ae6`): Callers treated the slot number as a register number; in `compute(5)`, `y = y + 1` would read `x` instead. Now it emits `LOAD_SLOT dst=new register` and returns that register.

3. **`let` declaration leaks as implicit return value** (`c3d65b4`): The `lastResultReg` from a trailing `let a = 1;` in a function body remained set, so the implicit `RETURN` returned `1`. When compiling `compileSequence`, track whether the last statement is a `let` declaration; `compileFunctionBody`/`Lambda` then set the implicit return to no value. Top-level scripts are unaffected (a trailing `let` still yields its value).

4. **VM integer division/power silently returns 0** (`0809771`): The int/int fast path in `execArithmetic` only handled ADD/SUB/MUL/MOD; DIV/POW fell into `default` after the result had already been written as 0, bypassing the generic `applyArithmetic`. The optimizer uses `applyArithmetic` and computed the correct floating-point value, so `10/4` yielded 2.5 with optimizations on and 0 with them off. Restricted the fast path to ADD/SUB/MUL/MOD; DIV/POW now fall through to the generic path.

5. **CSE incorrectly merges `instanceof` with different targets** (`841bb8c`): The CSE key for unary operations only used the op name + source register alias, ignoring `operand` (target class index), causing `a instanceof A` and `a instanceof B` to collide and the latter to be replaced by the former's result. The key now suffixes `#<operand>` to distinguish targets; operations without an operand use 0 and are unaffected.

6. **Missing dead value elimination** (`28383d3`): After constant folding/CSE, `LOAD_CONST` instructions that are no longer read still occupy the instruction stream. Added `DeadValuePass` (under the dead-code phase) to delete `LOAD_CONST` whose destination register is never read; conservative handling: call-consuming registers (`src1..src1+imm`) are marked as read, register 0 is fixed as the return value when `HALT` exists, `STORE_SLOT`/`LOAD_SLOT` `operand` registers are preserved, and jump targets are remapped after deletion. This makes the fully-optimized code expected by `PassMaskTurnsOffConstantFolding` shorter than without folding.

7. **Test construction defect** (`9352af4`): `RemovesDeadSlotStoreInStraightLineCode` constructed MIR with `slotCount=1` but accessed registers 0/1/2; slots and registers share a single numbering space (`Frame::localsSize = chunk.slotCount`), so unoptimized execution reported `Register index out of range`. Changed to `slotCount=4` with value registers 1/2/3.

## MIR serialization restoration (`20b2847`)

The MIR direct-execution refactor (`8e0c6e1`) removed `BytecodeSerializer` along with the bytecode layer, leaving compiled artifacts unable to be persisted. `MirSerializer` restores this capability with the same header/checksum wrapping (`LCUP`/`LCUD` magic numbers) as the old serializer:

- `serialize`/`deserialize`/`peekHeader` cover the complete `MirChunk`: all register fields and `TypeInfo` of `MirInstr`, all metadata tables (including `byNameCalls`), and nested method bodies.
- `serializeDebugInfo`/`attachDebugInfo` preserve per-instruction source locations keyed by body checksum.
- `ObjectRef`/`FunctionRefPtr` constants are rejected consistently with the old version (runtime-only).
- `MirSerializerTest` restores the scenarios covered by the old `BytecodeCacheTest` (10 test cases).

## Validation

Using an out-of-tree standalone checker (`loicc`, which compiles `src/LOICollectionA/frontend` without linking LeviLamina):

- 52 corpus scripts round-tripped through serialize→deserialize→run with **0 differences**; results across four modes (optimizations on/off/LICM off/only LICM) are **all identical** (equivalence + stress test).
- All 10 new serialization tests pass.
- Full test suite failures dropped from **173** at baseline (`6fa06d6`) to **3**. The remaining 3 `StdlibObservableTest.*` are local harness limitations (Observable class depends on LeviLamina, not included in the build) and pass in real CI.
- Difference set against baseline failures: **zero new regressions** (18 fixed, no new failures introduced).
- Benchmark geometric mean speedup: **2.229x** in off mode, **2.140x** in on mode.